### PR TITLE
Refactor formulating index.html file logic so we can use Ngrok to tes…

### DIFF
--- a/invitation-backend/src/app.ts
+++ b/invitation-backend/src/app.ts
@@ -1,5 +1,4 @@
 import express from 'express';
-import bodyParser from 'body-parser';
 import cors from 'cors';
 import path from 'path';
 import * as dotenv from 'dotenv';
@@ -15,8 +14,8 @@ const app = express();
 const port = 8080; // default port to listen
 
 app.use(cors());
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 // app.set('view engine', 'ejs');
 // app.set('views', path.join(__dirname, '..', '..', 'invitation-frontend', 'build'));
 

--- a/invitation-backend/src/utils/IndexFileUtil.ts
+++ b/invitation-backend/src/utils/IndexFileUtil.ts
@@ -14,8 +14,8 @@ export const updateIndexfile = (subdomain: string, indexFilePath: string): strin
         "<title>You have been invited!</title>"
       )
       .replace(
-        "<meta name=\"description\" content=\"Mobile Invitation/RSVP for Wedding\" data-rh=\"true\"/>",
-        "<meta name=\"description\" content=\"Welcome to Han & Jenny wedding!\" data-rh=\"true\"/>",
+        "<meta name=\"description\" content=\"Mobile Invitation/RSVP for Wedding\" data-rh=\"true\"",
+        "<meta name=\"description\" content=\"Welcome to Han & Jenny wedding!\" data-rh=\"true\"",
       )
       .replace(
         "<meta property=\"og:image\" content=\"/og_imgs/default_og_img.jpg\">",
@@ -32,8 +32,8 @@ export const updateIndexfile = (subdomain: string, indexFilePath: string): strin
         "<title>You have been invited!</title>"
       )
       .replace(
-        "<meta name=\"description\" content=\"Mobile Invitation/RSVP for Wedding\" data-rh=\"true\"/>",
-        "<meta name=\"description\" content=\"Welcome to Sam & Eunhee wedding!\" data-rh=\"true\"/>",
+        "<meta name=\"description\" content=\"Mobile Invitation/RSVP for Wedding\" data-rh=\"true\"",
+        "<meta name=\"description\" content=\"Welcome to Sam & Eunhee wedding!\" data-rh=\"true\"",
       )
       .replace(
         "<meta property=\"og:image\" content=\"/og_imgs/default_og_img.jpg\">",

--- a/invitation-backend/src/utils/IndexFileUtil.ts
+++ b/invitation-backend/src/utils/IndexFileUtil.ts
@@ -1,0 +1,49 @@
+import fs from 'fs';
+
+export const updateIndexfile = (subdomain: string, indexFilePath: string): string => {
+  const indexFile = fs.readFileSync(indexFilePath, 'utf8');
+  // Once we set the PUBLIC_URL in .env file, we need to update the code below.
+  const replacedPublicUrlIndexFile = indexFile.replace(/%PUBLIC_URL%/g, '');
+
+  if(subdomain === 'we') {
+    // This is where we can modify the build/index.html file.
+    // The purpose of this is to update the tags in the head tag in html.
+    const updatedIndexFile = replacedPublicUrlIndexFile
+      .replace(
+        "<title>Inviteyou</title>",
+        "<title>You have been invited!</title>"
+      )
+      .replace(
+        "<meta name=\"description\" content=\"Mobile Invitation/RSVP for Wedding\" data-rh=\"true\"/>",
+        "<meta name=\"description\" content=\"Welcome to Han & Jenny wedding!\" data-rh=\"true\"/>",
+      )
+      .replace(
+        "<meta property=\"og:image\" content=\"/og_imgs/default_og_img.jpg\">",
+        "<meta property=\"og:image\" content=\"/og_imgs/we_og_img.png\">"
+      );
+    // Debug purpose
+    console.log(updatedIndexFile);
+    
+    return updatedIndexFile;
+  } else if (subdomain === 'sne') {
+    const updatedIndexFile = replacedPublicUrlIndexFile
+      .replace(
+        "<title>Inviteyou</title>",
+        "<title>You have been invited!</title>"
+      )
+      .replace(
+        "<meta name=\"description\" content=\"Mobile Invitation/RSVP for Wedding\" data-rh=\"true\"/>",
+        "<meta name=\"description\" content=\"Welcome to Sam & Eunhee wedding!\" data-rh=\"true\"/>",
+      )
+      .replace(
+        "<meta property=\"og:image\" content=\"/og_imgs/default_og_img.jpg\">",
+        "<meta property=\"og:image\" content=\"/og_imgs/sne_og_img.png\">"
+      );
+    // Debug purpose
+    console.log(updatedIndexFile);
+
+    return updatedIndexFile;
+  }
+
+  return replacedPublicUrlIndexFile;
+};


### PR DESCRIPTION
We couldn't test og tags and other meta tags from the development environment. 

This PR includes the new route `test-subdomain/:subdomain` that we can use this route to test og tags and other meta tags.

> Note: Ngrok provides paid service with a subdomain but since we are using the free version, we don't have access to that feature so we decide to use a new route.