### PR TITLE
Add static marketing site for inviteyou.ca + www

### DIFF
--- a/.github/workflows/marketing-server-setup.yml
+++ b/.github/workflows/marketing-server-setup.yml
@@ -1,0 +1,86 @@
+name: Marketing Server Setup (Nginx/TLS)
+
+# Manual, konegolf-style server setup: SSHes into the SAME droplet that main.yml
+# already deploys to (via the existing SERVER_SSH_KEY / SSH_HOST / SSH_USER secrets)
+# and installs the static-site Nginx block for inviteyou.ca + www.
+#
+# This NEVER runs automatically. It only runs when you trigger it from the
+# Actions tab, and it defaults to a safe DRY-RUN that changes nothing on the
+# server. Set "apply" to the word "apply" to actually enable the site + reload.
+#
+# It leaves we.inviteyou.ca and api.inviteyou.ca completely untouched.
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Type 'apply' to enable the site and reload Nginx. Anything else = DRY-RUN (validate only, no changes)."
+        required: true
+        default: "dry-run"
+      run_certbot:
+        description: "Obtain/expand the TLS cert for inviteyou.ca + www (only if it doesn't already cover them)."
+        type: boolean
+        default: false
+
+jobs:
+  setup:
+    name: Configure Nginx on the droplet
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (for the Nginx conf)
+        uses: actions/checkout@v4
+
+      - name: Load deploy SSH key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SERVER_SSH_KEY }}
+
+      - name: Trust the droplet host key
+        run: |
+          if [ -z "${{ secrets.SSH_HOST }}" ]; then echo 'SSH_HOST secret missing' >&2; exit 1; fi
+          ssh-keyscan -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Show what currently serves apex/www (diagnostic)
+        run: |
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
+            "sudo grep -Rano 'server_name[^;]*;' /etc/nginx/sites-enabled/ /etc/nginx/conf.d/ 2>/dev/null || true"
+
+      - name: Ensure web root exists
+        run: |
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
+            "sudo mkdir -p '${{ secrets.MARKETING_TARGET_PATH }}' && sudo chown -R \$(whoami):www-data '${{ secrets.MARKETING_TARGET_PATH }}' || true"
+
+      - name: Upload the Nginx config to sites-available
+        run: |
+          scp marketing/nginx-inviteyou-marketing.conf \
+            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/tmp/inviteyou-marketing.conf
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
+            "sudo mv /tmp/inviteyou-marketing.conf /etc/nginx/sites-available/inviteyou-marketing"
+
+      - name: (Optional) Obtain TLS certificate
+        if: ${{ github.event.inputs.run_certbot == 'true' }}
+        run: |
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
+            "sudo certbot --nginx -d inviteyou.ca -d www.inviteyou.ca --non-interactive --agree-tos --redirect || true"
+
+      - name: Validate, then enable (apply) or roll back (dry-run)
+        run: |
+          APPLY='${{ github.event.inputs.apply }}'
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "APPLY='$APPLY' bash -s" <<'EOSSH'
+          set -e
+          LINK=/etc/nginx/sites-enabled/inviteyou-marketing
+          sudo ln -sf /etc/nginx/sites-available/inviteyou-marketing "$LINK"
+          if sudo nginx -t; then
+            if [ "$APPLY" = "apply" ]; then
+              sudo systemctl reload nginx
+              echo "✅ ENABLED: inviteyou.ca + www now served from the static site; Nginx reloaded."
+            else
+              sudo rm -f "$LINK"
+              echo "✅ DRY-RUN OK: config is valid. Left DISABLED, nothing reloaded. Re-run with apply='apply' to go live."
+            fi
+          else
+            sudo rm -f "$LINK"
+            echo "❌ nginx -t FAILED — rolled back, no changes applied." >&2
+            exit 1
+          fi
+          EOSSH

--- a/.github/workflows/marketing.yml
+++ b/.github/workflows/marketing.yml
@@ -1,0 +1,34 @@
+name: Deploy Marketing Site
+
+# Deploys the static marketing site (marketing/) to the droplet.
+# inviteyou.ca + www are served from this folder via a dedicated Nginx block.
+# The invitation app (we.inviteyou.ca) and api.inviteyou.ca are unaffected.
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "marketing/**"
+      - ".github/workflows/marketing.yml"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy static site over SSH
+        uses: easingthemes/ssh-deploy@v2.2.11
+        env:
+          # Reuses the existing deploy secrets
+          SSH_PRIVATE_KEY: ${{ secrets.SERVER_SSH_KEY }}
+          REMOTE_HOST: ${{ secrets.SSH_HOST }}
+          REMOTE_USER: ${{ secrets.SSH_USER }}
+          # New dedicated target directory on the server (e.g. /var/www/inviteyou-web)
+          TARGET: ${{ secrets.MARKETING_TARGET_PATH }}
+          # Only the static site folder; trailing slash copies its contents
+          SOURCE: "marketing/"
+          # Keep the remote dir in sync and skip local tooling
+          ARGS: "-rltgoDzvO --delete"
+          EXCLUDE: "/build_site.py, /connect_nav.py, /.DS_Store"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ All hostnames resolve to the same droplet (`147.182.215.135`); Nginx routes by h
 | `we.inviteyou.ca` | Invitation app (React SPA) | `main.yml` deploy target |
 | `api.inviteyou.ca` | Invitation backend (Express/MongoDB) | `main.yml` deploy target |
 
+> **Status:** the marketing site is **live** — `inviteyou.ca` + `www` serve the
+> static site; `we.` / `api.` are unchanged. See [`marketing/DEPLOY.md`](marketing/DEPLOY.md)
+> for the deployed Nginx config and rollback steps.
+
 ---
 
 # 1. Invitation app (existing MERN product)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ See **[`marketing/DEPLOY.md`](marketing/DEPLOY.md)** for the one-time Nginx/TLS
 setup on the droplet, verification commands, and rollback steps. The Nginx server
 block lives in [`marketing/nginx-inviteyou-marketing.conf`](marketing/nginx-inviteyou-marketing.conf).
 
+There are two ways to do the server setup:
+- **Automated (recommended):** run the **`Marketing Server Setup (Nginx/TLS)`**
+  workflow (`.github/workflows/marketing-server-setup.yml`) from the Actions tab.
+  It SSHes into the droplet using the existing deploy secrets and installs the
+  Nginx block for you (defaults to a safe dry-run; set `apply=apply` to go live).
+- **Manual:** follow the SSH steps in `marketing/DEPLOY.md`.
+
 ---
 
 # CI / CD
@@ -121,6 +128,15 @@ Both deploys reuse the same SSH secrets: `SERVER_SSH_KEY`, `SSH_HOST`, `SSH_USER
 - **Does:** rsyncs the `marketing/` folder over SSH to `MARKETING_TARGET_PATH`
   (default `/var/www/inviteyou-web`) with `--delete`, excluding the `.py`
   generator scripts (serves `inviteyou.ca` / `www`).
+
+## `marketing-server-setup.yml` — One-time Nginx/TLS setup
+- **Trigger:** manual **workflow_dispatch** only (never runs automatically).
+- **Does:** SSHes into the droplet with the existing `SERVER_SSH_KEY` / `SSH_HOST`
+  / `SSH_USER` secrets (the same droplet + access pattern the `konegolf` repo
+  uses) to install the apex/www Nginx block, optionally run `certbot`, validate
+  with `nginx -t`, and reload. Defaults to a safe **dry-run** (auto-rolls back,
+  changes nothing); set input `apply=apply` to actually enable + reload. Leaves
+  `we.` / `api.` untouched.
 
 ### Does the marketing pipeline only trigger on marketing changes?
 **Yes** — `marketing.yml` only runs when files inside `marketing/**` (or its own

--- a/README.md
+++ b/README.md
@@ -1,13 +1,59 @@
 # inviteyou
 
-## Tech Stacks
+This repository contains **two independent deliverables** that ship to the same
+DigitalOcean droplet but are otherwise unrelated:
+
+| # | What | Lives in | Served at | Deployed by |
+|---|------|----------|-----------|-------------|
+| 1 | **Invitation app** (existing MERN product) | `invitation-frontend/`, `invitation-backend/` | `we.inviteyou.ca` (app) + `api.inviteyou.ca` (backend) | `.github/workflows/main.yml` |
+| 2 | **Marketing site** (new static site) | `marketing/` | `inviteyou.ca` + `www.inviteyou.ca` | `.github/workflows/marketing.yml` |
+
+> The two are deployed separately and do not affect each other. Changing the
+> marketing site never redeploys the app's runtime, and vice versa.
+
+---
+
+## Repository structure
+
+```
+.
+├── invitation-frontend/   # React + TypeScript SPA (the invitation app UI)
+├── invitation-backend/    # Express + MongoDB API
+├── marketing/             # Static marketing site (HTML + Tailwind CDN)
+│   ├── *.html             # 9 pages (index, about, services, solutions,
+│   │                      #          process, portfolio, contact, careers, faq)
+│   ├── build_site.py      # Generator: normalizes filenames + rewires links
+│   ├── connect_nav.py     # Generator: standardizes header/footer nav
+│   ├── nginx-inviteyou-marketing.conf  # Nginx server block for apex + www
+│   └── DEPLOY.md          # One-time server/Nginx setup, verify, rollback
+└── .github/workflows/
+    ├── main.yml           # Builds + deploys the app (we. / api.)
+    └── marketing.yml      # Deploys the static marketing site (apex / www)
+```
+
+## Domain / hostname map
+
+All hostnames resolve to the same droplet (`147.182.215.135`); Nginx routes by host:
+
+| Hostname | Serves | Backed by |
+|----------|--------|-----------|
+| `inviteyou.ca` | Marketing site | Static files in `/var/www/inviteyou-web` |
+| `www.inviteyou.ca` | Redirects to `inviteyou.ca` | Nginx redirect |
+| `we.inviteyou.ca` | Invitation app (React SPA) | `main.yml` deploy target |
+| `api.inviteyou.ca` | Invitation backend (Express/MongoDB) | `main.yml` deploy target |
+
+---
+
+# 1. Invitation app (existing MERN product)
+
+## Tech stack
 - ReactJS
 - ExpressJS
 - MongoDB
 - TypeScript
 
 ## How to start
-1. Need to fill up the `.env` file. Please fill the values in `.env.example` file and remove the `.example` extension.
+1. Fill up the `.env` file. Copy the values from the `.env.example` file and remove the `.example` extension.
 2. Run `npm install` under `/invitation-frontend` and `/invitation-backend` to install dependencies.
 
 ## Frontend `.env`
@@ -25,7 +71,78 @@
   MONGO_DB_NAME=test
 ```
 
-## This is mobile invitaion project.
+This is a mobile invitation project.
+
+---
+
+# 2. Marketing site (new static site)
+
+A 9-page static marketing site built from the Stitch "Luminous Professionalism"
+design (Tailwind via CDN, Hanken Grotesk / Inter / JetBrains Mono, electric-blue
+`#0062FF`, glassmorphic nav, scroll-reveal animations). All pages are
+cross-linked with a standardized header and footer.
+
+## Local preview
+```bash
+cd marketing
+python3 -m http.server 8000
+# open http://localhost:8000/index.html
+```
+
+## Regenerating pages
+The pages were produced from the design exports by two helper scripts (kept for
+reproducibility):
+- `build_site.py` — copies source pages to clean filenames and rewires `href="#"`
+  links by their label text.
+- `connect_nav.py` — injects a consistent header + footer into every page so all
+  pages (including FAQ and Careers) are reachable.
+
+## Server setup & deployment
+See **[`marketing/DEPLOY.md`](marketing/DEPLOY.md)** for the one-time Nginx/TLS
+setup on the droplet, verification commands, and rollback steps. The Nginx server
+block lives in [`marketing/nginx-inviteyou-marketing.conf`](marketing/nginx-inviteyou-marketing.conf).
+
+---
+
+# CI / CD
+
+Both deploys reuse the same SSH secrets: `SERVER_SSH_KEY`, `SSH_HOST`, `SSH_USER`.
+
+## `main.yml` — Invitation app
+- **Trigger:** a pull request to `main` is **closed** (i.e. merged), or manual
+  **workflow_dispatch**. It has **no path filter**, so it runs on *every* merged
+  PR regardless of which files changed.
+- **Does:** builds the React frontend + Express backend, then SSH-deploys to
+  `TARGET_PATH` and restarts the app (serves `we.` / `api.`).
+
+## `marketing.yml` — Marketing site
+- **Trigger:** a push to `main` that changes files under **`marketing/**`** (or
+  the `marketing.yml` workflow file itself), or manual **workflow_dispatch**.
+- **Does:** rsyncs the `marketing/` folder over SSH to `MARKETING_TARGET_PATH`
+  (default `/var/www/inviteyou-web`) with `--delete`, excluding the `.py`
+  generator scripts (serves `inviteyou.ca` / `www`).
+
+### Does the marketing pipeline only trigger on marketing changes?
+**Yes** — `marketing.yml` only runs when files inside `marketing/**` (or its own
+workflow file) change on `main`, plus manual dispatch.
+
+**But the reverse is not symmetric:** `main.yml` (the app pipeline) has **no
+`paths:` filter** and fires on *any* merged PR. So merging a marketing-only PR
+will still trigger an app rebuild + redeploy. That redeploys the same app and is
+harmless, just redundant. If you want the app pipeline to skip marketing-only
+changes, add a `paths-ignore: ["marketing/**"]` filter to `main.yml`.
+
+## Required GitHub secrets
+| Secret | Used by | Purpose |
+|--------|---------|---------|
+| `SERVER_SSH_KEY` | both | SSH private key for the droplet |
+| `SSH_HOST` | both | Droplet host/IP |
+| `SSH_USER` | both | SSH user |
+| `TARGET_PATH` | `main.yml` | App deploy directory |
+| `MARKETING_TARGET_PATH` | `marketing.yml` | Static site directory (`/var/www/inviteyou-web`) |
+| `MONGO_DB_USERNAME` / `MONGO_DB_PASSWORD` / `MONGO_DB_NAME` | `main.yml` | App build/runtime |
+
+---
 
 ## Contact us
 - Hailey Yang

--- a/marketing/DEPLOY.md
+++ b/marketing/DEPLOY.md
@@ -10,7 +10,43 @@ This folder holds the **static marketing site** served at `https://inviteyou.ca`
 
 ---
 
-## Option A — Automated (recommended, no local SSH needed)
+## ✅ Status: LIVE (deployed 2026-07-06)
+
+The server-side Nginx setup below has **already been applied** to the droplet
+(`147.182.215.135`). Current live routing:
+
+| Host | Serves |
+|------|--------|
+| `inviteyou.ca` | Static marketing site (`/var/www/inviteyou-web`) |
+| `www.inviteyou.ca` | 301 redirect → `inviteyou.ca` |
+| `we.inviteyou.ca` | React invitation app (unchanged) |
+| `api.inviteyou.ca` | Express/MongoDB backend (unchanged) |
+| `k-golf.inviteyou.ca` | K one Golf (unchanged) |
+
+**How it was actually done:** rather than a separate site file, the apex + www
+handling was integrated into the existing `/etc/nginx/sites-available/inviteyou.ca`
+so the `k-golf.inviteyou.ca` and `*.inviteyou.ca` (we./api.) server blocks are
+preserved verbatim. The full deployed config is checked in as
+[`nginx-inviteyou-marketing.conf`](./nginx-inviteyou-marketing.conf). Certs reused:
+apex uses `inviteyou.ca-0001`, www reuses the `*.inviteyou.ca` wildcard cert
+`inviteyou.ca-0002` (no new certbot needed). A timestamped backup of the previous
+config was saved on the server as `/etc/nginx/sites-available/inviteyou.ca.bak.*`.
+
+**Rollback:** restore the backup and reload —
+```bash
+ssh root@147.182.215.135 \
+  'cp $(ls -t /etc/nginx/sites-available/inviteyou.ca.bak.* | head -1) \
+      /etc/nginx/sites-available/inviteyou.ca && nginx -t && systemctl reload nginx'
+```
+
+Ongoing content updates deploy automatically via `.github/workflows/marketing.yml`
+(rsync to `MARKETING_TARGET_PATH` = `/var/www/inviteyou-web`).
+
+---
+
+The sections below document the setup for reference / re-creation from scratch.
+
+## Option A — Automated (workflow, no local SSH needed)
 
 The repo already has SSH access to the droplet (the same secrets `main.yml` uses:
 `SERVER_SSH_KEY` / `SSH_HOST` / `SSH_USER`). The **`Marketing Server Setup (Nginx/TLS)`**

--- a/marketing/DEPLOY.md
+++ b/marketing/DEPLOY.md
@@ -1,0 +1,76 @@
+# Marketing site deployment (server / Nginx)
+
+This folder holds the **static marketing site** served at `https://inviteyou.ca` and
+`https://www.inviteyou.ca`. It is deployed by `.github/workflows/marketing.yml`
+(SSH deploy) to the server directory in the `MARKETING_TARGET_PATH` secret
+(default: `/var/www/inviteyou-web`).
+
+**Untouched by this change:** `we.inviteyou.ca` (the React invitation app) and
+`api.inviteyou.ca` (Express/MongoDB backend).
+
+---
+
+## One-time server setup (run on the droplet via SSH)
+
+> Requires SSH access to `147.182.215.135` with sudo.
+
+### 1. Create the web root (must match `MARKETING_TARGET_PATH`)
+```bash
+sudo mkdir -p /var/www/inviteyou-web
+sudo chown -R "$USER":www-data /var/www/inviteyou-web
+```
+
+### 2. Inspect the current config to see what serves the apex today
+```bash
+grep -Rano "server_name[^;]*;" /etc/nginx/sites-enabled/ /etc/nginx/conf.d/ 2>/dev/null
+```
+Find the `server` block whose `server_name` matches `inviteyou.ca`/`www.inviteyou.ca`
+(likely a `proxy_pass` to the Node/Express app). You will replace **only that block's
+apex/www handling** with the static block below. Leave `we.inviteyou.ca` and
+`api.inviteyou.ca` blocks exactly as they are.
+
+### 3. Add the static server block
+Create `/etc/nginx/sites-available/inviteyou-marketing` with the contents of
+[`nginx-inviteyou-marketing.conf`](./nginx-inviteyou-marketing.conf) from this folder,
+then enable it:
+```bash
+sudo ln -sf /etc/nginx/sites-available/inviteyou-marketing /etc/nginx/sites-enabled/inviteyou-marketing
+```
+> If the apex/www is currently handled inside the same block as `we.`/`api.`, instead
+> remove `inviteyou.ca www.inviteyou.ca` from that block's `server_name` (and its
+> apex/www TLS) so this new block takes over those two names.
+
+### 4. TLS certificate
+If the existing certificate does **not** already include the apex + www names, issue it:
+```bash
+sudo certbot --nginx -d inviteyou.ca -d www.inviteyou.ca
+```
+(Skip if the cert already covers them — the site already serves HTTPS today.)
+
+### 5. Test & reload
+```bash
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+---
+
+## Deploy the files
+- Automatic: merge `add-marketing-site` → `main`; the `Deploy Marketing Site` workflow
+  runs on changes under `marketing/**` and rsyncs the files to `/var/www/inviteyou-web`.
+- Manual trigger: GitHub → Actions → **Deploy Marketing Site** → *Run workflow*.
+
+## Verify
+```bash
+curl -sI https://inviteyou.ca | grep -i '^HTTP\|^content-type'
+curl -s  https://inviteyou.ca | grep -o '<title>[^<]*</title>'      # -> InviteYou.ca marketing
+curl -s  https://we.inviteyou.ca | grep -o '<title>[^<]*</title>'   # -> You have been invited! (unchanged)
+curl -sI https://api.inviteyou.ca | grep -i '^HTTP'                 # -> app/API unchanged
+```
+
+## Rollback
+Re-add `inviteyou.ca www.inviteyou.ca` to the previous (proxy-to-Express) `server`
+block — or disable this one:
+```bash
+sudo rm /etc/nginx/sites-enabled/inviteyou-marketing
+sudo nginx -t && sudo systemctl reload nginx
+```

--- a/marketing/DEPLOY.md
+++ b/marketing/DEPLOY.md
@@ -10,7 +10,30 @@ This folder holds the **static marketing site** served at `https://inviteyou.ca`
 
 ---
 
-## One-time server setup (run on the droplet via SSH)
+## Option A — Automated (recommended, no local SSH needed)
+
+The repo already has SSH access to the droplet (the same secrets `main.yml` uses:
+`SERVER_SSH_KEY` / `SSH_HOST` / `SSH_USER`). The **`Marketing Server Setup (Nginx/TLS)`**
+workflow (`.github/workflows/marketing-server-setup.yml`) does the server setup
+for you over SSH — the same way the `konegolf` repo configures this droplet.
+
+1. GitHub → **Actions** → **Marketing Server Setup (Nginx/TLS)** → **Run workflow**.
+2. Leave `apply` as `dry-run` for the first run. It will:
+   - print the current `server_name` blocks (so you can see what serves apex/www today),
+   - create the web root, upload the Nginx config, and run `nginx -t`,
+   - **change nothing** (auto-rolls back the symlink) — safe to run anytime.
+   - Set `run_certbot: true` on this run if the TLS cert doesn't yet cover apex + www.
+3. Review the dry-run log. If the apex/www is currently handled inside the same
+   block as `we.`/`api.`, first remove `inviteyou.ca www.inviteyou.ca` from that
+   block's `server_name` (see Option B step 2) so there's no conflict.
+4. Re-run the workflow with **`apply` = `apply`** to enable the site and reload Nginx.
+   On any `nginx -t` failure it automatically rolls back and makes no changes.
+
+> Prefer doing it by hand? Use **Option B** below.
+
+---
+
+## Option B — Manual one-time server setup (run on the droplet via SSH)
 
 > Requires SSH access to `147.182.215.135` with sudo.
 

--- a/marketing/about.html
+++ b/marketing/about.html
@@ -1,0 +1,347 @@
+<!DOCTYPE html><html class="scroll-smooth" lang="en" style=""><head>
+<meta charset="utf-8">
+<meta content="width=device-width, initial-scale=1.0" name="viewport">
+<title>About Us | InviteYou.ca</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;600;700;800&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@500&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet">
+<script id="tailwind-config">
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            "colors": {
+                    "on-primary-fixed": "#00174b",
+                    "on-background": "#181c20",
+                    "tertiary-container": "#b35052",
+                    "on-secondary": "#ffffff",
+                    "primary": "#004cca",
+                    "surface-container-high": "#e5e8ee",
+                    "on-tertiary-fixed": "#410007",
+                    "inverse-on-surface": "#eef1f6",
+                    "tertiary": "#94393b",
+                    "electric-blue": "#0062FF",
+                    "tertiary-fixed-dim": "#ffb3b1",
+                    "on-tertiary-container": "#fff1ef",
+                    "on-surface-variant": "#424656",
+                    "ghost-white": "#F8F9FA",
+                    "on-error": "#ffffff",
+                    "background": "#f7f9ff",
+                    "primary-fixed-dim": "#b4c5ff",
+                    "surface-tint": "#0053da",
+                    "on-secondary-fixed": "#002116",
+                    "tertiary-fixed": "#ffdad8",
+                    "inverse-primary": "#b4c5ff",
+                    "surface-container-highest": "#e0e3e8",
+                    "surface-container-low": "#f1f4f9",
+                    "surface-container": "#ebeef3",
+                    "inverse-surface": "#2d3135",
+                    "on-tertiary": "#ffffff",
+                    "surface": "#f7f9ff",
+                    "secondary-fixed": "#67fcc6",
+                    "secondary-container": "#67fcc6",
+                    "on-secondary-container": "#007354",
+                    "error-container": "#ffdad6",
+                    "on-error-container": "#93000a",
+                    "error": "#ba1a1a",
+                    "outline-variant": "#c2c6d9",
+                    "surface-variant": "#e0e3e8",
+                    "on-primary-fixed-variant": "#003ea8",
+                    "primary-container": "#0062ff",
+                    "on-tertiary-fixed-variant": "#7f292c",
+                    "primary-fixed": "#dbe1ff",
+                    "surface-bright": "#f7f9ff",
+                    "on-secondary-fixed-variant": "#00513a",
+                    "on-primary": "#ffffff",
+                    "secondary": "#006c4f",
+                    "on-surface": "#181c20",
+                    "surface-container-lowest": "#ffffff",
+                    "surface-dim": "#d7dadf",
+                    "secondary-fixed-dim": "#44dfab",
+                    "on-primary-container": "#f3f3ff",
+                    "soft-teal": "#20C997",
+                    "surface-subtle": "#FBF2F2",
+                    "outline": "#737687"
+            },
+            "borderRadius": {
+                    "DEFAULT": "0.25rem",
+                    "lg": "0.5rem",
+                    "xl": "0.75rem",
+                    "full": "9999px"
+            },
+            "spacing": {
+                    "margin-mobile": "16px",
+                    "unit": "4px",
+                    "max-width": "1280px",
+                    "margin-desktop": "64px",
+                    "gutter": "24px"
+            },
+            "fontFamily": {
+                    "headline-md": ["Hanken Grotesk"],
+                    "label-md": ["JetBrains Mono"],
+                    "body-md": ["Inter"],
+                    "label-sm": ["JetBrains Mono"],
+                    "headline-lg": ["Hanken Grotesk"],
+                    "headline-xl": ["Hanken Grotesk"],
+                    "headline-lg-mobile": ["Hanken Grotesk"],
+                    "body-lg": ["Inter"]
+            },
+            "fontSize": {
+                    "headline-md": ["32px", {"lineHeight": "40px", "fontWeight": "600"}],
+                    "label-md": ["14px", {"lineHeight": "20px", "letterSpacing": "0.05em", "fontWeight": "500"}],
+                    "body-md": ["16px", {"lineHeight": "24px", "fontWeight": "400"}],
+                    "label-sm": ["12px", {"lineHeight": "16px", "letterSpacing": "0.05em", "fontWeight": "500"}],
+                    "headline-lg": ["48px", {"lineHeight": "56px", "letterSpacing": "-0.01em", "fontWeight": "600"}],
+                    "headline-xl": ["64px", {"lineHeight": "72px", "letterSpacing": "-0.02em", "fontWeight": "700"}],
+                    "headline-lg-mobile": ["32px", {"lineHeight": "40px", "fontWeight": "600"}],
+                    "body-lg": ["18px", {"lineHeight": "28px", "fontWeight": "400"}]
+            }
+          },
+        },
+      }
+    </script>
+<style>
+        .glass-card {
+            background: rgba(255, 255, 255, 0.7);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+            border: 1px solid rgba(233, 236, 239, 0.5);
+        }
+        .material-symbols-outlined {
+            font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+        }
+        .step-line::after {
+            content: '';
+            position: absolute;
+            left: 50%;
+            top: 2rem;
+            bottom: -2rem;
+            width: 2px;
+            background: repeating-linear-gradient(to bottom, #0062FF 0, #0062FF 8px, transparent 8px, transparent 16px);
+            transform: translateX(-50%);
+        }
+        @media (max-width: 768px) {
+            .step-line::after {
+                left: 1rem;
+            }
+        }
+    </style>
+</head>
+<body class="bg-background text-on-background font-body-md selection:bg-electric-blue selection:text-white">
+<!-- TopNavBar -->
+<header class="fixed top-0 left-0 w-full z-50 bg-surface/70 backdrop-blur-xl shadow-sm">
+<div class="flex justify-between items-center max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-4">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary tracking-tight" style="cursor:pointer">InviteYou.ca</a>
+<nav class="hidden md:flex items-center space-x-8">
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="services.html">Services</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="solutions.html">Solutions</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="process.html">Process</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="portfolio.html">Portfolio</a>
+<a class="text-primary border-b-2 border-primary pb-1 font-semibold font-label-md text-label-md" href="about.html">About</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="contact.html">Contact</a>
+</nav>
+<a href="contact.html"><button class="bg-primary-container text-on-primary-container px-6 py-2.5 rounded-full font-label-md text-label-md hover:scale-105 hover:shadow-md transition-all duration-200 active:scale-95">Get Started</button></a>
+</div>
+</header>
+<main class="pt-20">
+<!-- Hero Section -->
+<section class="relative py-24 md:py-32 overflow-hidden px-margin-mobile md:px-margin-desktop">
+
+<div class="max-w-max-width mx-auto text-center">
+<span class="inline-block px-4 py-1.5 rounded-full bg-primary/10 text-electric-blue font-label-sm text-label-sm mb-6 uppercase">Our Story</span>
+<h1 class="font-headline-xl text-headline-xl mb-8 tracking-tight">
+                    The Team Behind the <span class="text-electric-blue">Innovation</span>
+</h1>
+<p class="font-body-lg text-body-lg text-on-surface-variant max-w-2xl mx-auto leading-relaxed">
+                    We bridge the gap between complex engineering and human-centric design. At InviteYou.ca, we don't just build software; we architect experiences that drive business growth and social impact.
+                </p>
+</div>
+</section>
+<!-- Mission & Values Section -->
+<section class="py-24 bg-surface-container-lowest px-margin-mobile md:px-margin-desktop">
+<div class="max-w-max-width mx-auto">
+<div class="grid grid-cols-1 md:grid-cols-3 gap-gutter">
+<!-- Integrity Card -->
+<div class="glass-card p-10 rounded-xl hover:-translate-y-2 transition-transform duration-300 transition-all duration-700 opacity-100">
+<div class="w-16 h-16 rounded-lg bg-primary/10 flex items-center justify-center mb-8">
+<span class="material-symbols-outlined text-electric-blue text-4xl" data-icon="verified_user">verified_user</span>
+</div>
+<h3 class="font-headline-md text-headline-md mb-4 text-on-surface">Integrity</h3>
+<p class="font-body-md text-body-md text-on-surface-variant leading-relaxed">
+                            Trust is our core currency. We maintain absolute transparency in our processes, pricing, and communication, ensuring our partners always know exactly where their project stands.
+                        </p>
+</div>
+<!-- Innovation Card -->
+<div class="glass-card p-10 rounded-xl hover:-translate-y-2 transition-transform duration-300 transition-all duration-700 opacity-100">
+<div class="w-16 h-16 rounded-lg bg-soft-teal/10 flex items-center justify-center mb-8">
+<span class="material-symbols-outlined text-soft-teal text-4xl" data-icon="lightbulb">lightbulb</span>
+</div>
+<h3 class="font-headline-md text-headline-md mb-4 text-on-surface">Innovation</h3>
+<p class="font-body-md text-body-md text-on-surface-variant leading-relaxed">
+                            We aren't satisfied with standard solutions. Our team constantly explores emerging technologies like AI and decentralized systems to provide a competitive edge for our clients.
+                        </p>
+</div>
+<!-- Impact Card -->
+<div class="glass-card p-10 rounded-xl hover:-translate-y-2 transition-transform duration-300 transition-all duration-700 opacity-100">
+<div class="w-16 h-16 rounded-lg bg-tertiary/10 flex items-center justify-center mb-8">
+<span class="material-symbols-outlined text-tertiary text-4xl" data-icon="auto_graph">auto_graph</span>
+</div>
+<h3 class="font-headline-md text-headline-md mb-4 text-on-surface">Impact</h3>
+<p class="font-body-md text-body-md text-on-surface-variant leading-relaxed">
+                            Measurement defines success. We focus on delivering tangible results that improve operational efficiency, increase user retention, and maximize ROI for every stakeholder.
+                        </p>
+</div>
+</div>
+</div>
+</section>
+<!-- Our Process (Vertical Timeline) -->
+<section class="py-32 px-margin-mobile md:px-margin-desktop relative">
+<div class="max-w-4xl mx-auto">
+<div class="text-center mb-20">
+<h2 class="font-headline-lg text-headline-lg mb-4">Our Process</h2>
+<p class="font-body-md text-body-md text-on-surface-variant">How we transform your vision into a high-performance digital asset.</p>
+</div>
+<div class="space-y-24 relative md:items-center"><div class="absolute left-8 md:left-8 top-8 bottom-8 w-0.5 border-l-2 border-dashed border-electric-blue/30 -translate-x-1/2 z-0"></div>
+<!-- Step 1: Discovery -->
+<div class="flex flex-col md:flex-row items-center md:items-start gap-12 relative">
+<div class="flex-shrink-0 w-16 h-16 rounded-full bg-electric-blue text-white flex items-center justify-center font-headline-md text-headline-md z-10 shadow-lg shadow-electric-blue/20">1</div>
+<div class="flex-grow glass-card p-8 rounded-xl w-full transition-all duration-700 opacity-100"><div class="absolute -left-6 top-8 w-3 h-3 rounded-full bg-electric-blue/20 blur-[2px] hidden md:block"></div>
+<div class="flex items-center gap-4 mb-4">
+<span class="material-symbols-outlined text-electric-blue" data-icon="search">search</span>
+<h4 class="font-headline-md text-headline-md">Discovery</h4>
+</div>
+<p class="font-body-md text-body-md text-on-surface-variant mb-6">
+                                We begin by immersing ourselves in your business ecosystem. Through workshops and data analysis, we identify core challenges, user pain points, and strategic opportunities.
+                            </p>
+<div class="h-48 rounded-lg overflow-hidden bg-surface-variant">
+<div class="w-full h-full bg-cover bg-center" data-alt="A professional collaborative workspace with a diverse team of strategists and designers huddled around a clean, white conference table covered in colorful sticky notes and digital tablets. The scene is illuminated by soft, natural sunlight coming through floor-to-ceiling windows, casting long shadows. The overall aesthetic is minimalist, corporate, and highly focused, featuring a bright light-mode color palette with electric blue accents." style="background-image: url('https://lh3.googleusercontent.com/aida-public/AB6AXuAvGAPm1ebDU5z0Ou6Cm8cCc2A9H4KdNYVKzIpd4_YQXN6GAqqkUlvKX3Qq4Sp0Cks3i0pFb5hPtKKWneHSpXFxB6WGFhj8gubu5JY40TnRZzI5gHxBDvNTOMotVxnUkLw_zxTuiF3rI760SJdtj_tK06x4P4BweE8Cz0NLLD38EIn-64cfWcee8wdjsyXNz5kBAgUC-oKEmS_7rVEBm2K-gaWwCmiuBOElf6wnA_wY92QsiU0EuBa-dq4DRyEnsbcRjRHG9OV68pU')"></div>
+</div>
+</div>
+</div>
+<!-- Step 2: Design -->
+<div class="flex flex-col md:flex-row items-center md:items-start gap-12 relative">
+<div class="flex-shrink-0 w-16 h-16 rounded-full bg-electric-blue text-white flex items-center justify-center font-headline-md text-headline-md z-10 shadow-lg shadow-electric-blue/20">2</div>
+<div class="flex-grow glass-card p-8 rounded-xl w-full transition-all duration-700 opacity-100"><div class="absolute -left-6 top-8 w-3 h-3 rounded-full bg-electric-blue/20 blur-[2px] hidden md:block"></div>
+<div class="flex items-center gap-4 mb-4">
+<span class="material-symbols-outlined text-electric-blue" data-icon="palette">palette</span>
+<h4 class="font-headline-md text-headline-md">Design</h4>
+</div>
+<p class="font-body-md text-body-md text-on-surface-variant mb-6">
+                                Our design phase translates strategy into visual language. We create high-fidelity prototypes that prioritize intuitive navigation, accessibility, and brand consistency.
+                            </p>
+<div class="h-48 rounded-lg overflow-hidden bg-surface-variant">
+<div class="w-full h-full bg-cover bg-center" data-alt="A close-up view of a high-resolution computer screen displaying a complex user interface design system. The interface features elegant typography, glassmorphic card components, and vibrant electric blue buttons. In the foreground, a professional designer's hand is visible using a precise digital stylus. The studio lighting is soft and neutral, creating a premium, tech-focused atmosphere with deep focus on the crisp UI details." style="background-image: url('https://lh3.googleusercontent.com/aida-public/AB6AXuB76E6LJ6urfWVfyfLTP03wiXEWiE-yypEhhHyswV_lW0n3TDEfOK_rMqUHSf13Oes8KqOGKB-eHhfRQICiEZgYdkEQhhFC2S2oBDGvYaUn6sZ5UtVUrKj893W4Cu1i98OZ1BZrylbaNx-9RrysiiUY6WNdnbvryIE7JXAx8rMHw-TQEFXD1tC-14V5lbe1UgNVjqFzAlSiNoRb4gCC_U4FnS43Xr28NDRXEr1JrwPHZid_JfFn0ccFme8uc2S3qhECMraDpIqZRgA')"></div>
+</div>
+</div>
+</div>
+<!-- Step 3: Deployment -->
+<div class="flex flex-col md:flex-row items-center md:items-start gap-12 relative">
+<div class="flex-shrink-0 w-16 h-16 rounded-full bg-electric-blue text-white flex items-center justify-center font-headline-md text-headline-md z-10 shadow-lg shadow-electric-blue/20">3</div>
+<div class="flex-grow glass-card p-8 rounded-xl w-full transition-all duration-700 opacity-100"><div class="absolute -left-6 top-8 w-3 h-3 rounded-full bg-electric-blue/20 blur-[2px] hidden md:block"></div>
+<div class="flex items-center gap-4 mb-4">
+<span class="material-symbols-outlined text-electric-blue" data-icon="rocket_launch">rocket_launch</span>
+<h4 class="font-headline-md text-headline-md">Deployment</h4>
+</div>
+<p class="font-body-md text-body-md text-on-surface-variant mb-6">
+                                We leverage modern dev-ops and cloud infrastructure to ensure your solution is scalable, secure, and performs flawlessly from the first second of launch.
+                            </p>
+<div class="h-48 rounded-lg overflow-hidden bg-surface-variant">
+<div class="w-full h-full bg-cover bg-center" data-alt="A futuristic server room with rows of sleek, modern data racks glowing with soft blue LED indicators. The floor is a polished white surface reflecting the symmetrical lines of the technological infrastructure. The lighting is high-key and clean, suggesting high-speed connectivity and maximum security. The atmosphere is quiet, powerful, and represents cutting-edge cloud deployment and software engineering excellence." style="background-image: url('https://lh3.googleusercontent.com/aida-public/AB6AXuC0QCmEV5nCF1JN3tMCrNopQxlA8u8SWKyWTm9o3WxJ5puL3o401qz9geD-8ZJL26OxZppk1lpJsGf0vUQItLVuqK1J95Mz2ZvhYR77XGyeBhMZnIR-82GiAU8FXT3aP4N9HFqYs0XU6rQgpksqJx_thi0ZWlSbNj9QHsvYsHYfJLHQKy0WkswTb0h1WZ3aEwmu-xgEs5Q1jgz5s8Gg2wequln8TakN9qaZ6wAApN_DBXir3JXP8aikdVpuZXiCBwJWyxQrnvcpsGk')"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+<!-- CTA Section -->
+<section class="py-24 px-margin-mobile md:px-margin-desktop">
+<div class="max-w-max-width mx-auto bg-primary-container rounded-3xl p-12 md:p-20 text-center relative overflow-hidden">
+<div class="absolute inset-0 bg-gradient-to-br from-electric-blue to-primary opacity-50"></div>
+<div class="relative z-10">
+<h2 class="font-headline-lg text-headline-lg text-white mb-6">Ready to innovate together?</h2>
+<p class="font-body-lg text-body-lg text-on-primary-container/90 mb-10 max-w-xl mx-auto">
+                        Join our portfolio of industry leaders and let's build something exceptional.
+                    </p>
+<div class="flex flex-col sm:flex-row justify-center gap-4">
+<button class="bg-white text-electric-blue px-10 py-4 rounded-full font-label-md text-label-md font-bold hover:shadow-xl transition-all duration-300">
+                            Book a Strategy Session
+                        </button>
+<button class="border border-white/30 text-white px-10 py-4 rounded-full font-label-md text-label-md font-bold hover:bg-white/10 transition-all duration-300">View Portfolio</button>
+</div>
+</div>
+</div>
+</section>
+</main>
+<!-- Footer -->
+<footer class="w-full bg-surface-container-lowest border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-16 grid grid-cols-2 md:grid-cols-4 gap-8">
+<div class="col-span-2 md:col-span-1">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary" style="cursor:pointer">InviteYou.ca</a>
+<p class="font-body-md text-body-md text-on-surface-variant mt-4 max-w-xs">Architecting custom business solutions with high-tech innovation and institutional reliability.</p>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Company</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="about.html">About</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="careers.html">Careers</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Contact</a></li>
+</ul>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Expertise</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="services.html">Services</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="solutions.html">Solutions</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="process.html">Process</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="portfolio.html">Portfolio</a></li>
+</ul>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Support</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="faq.html">FAQ</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Contact</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Get Started</a></li>
+</ul>
+</div>
+</div>
+<div class="border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-6 flex flex-col md:flex-row justify-between items-center gap-4">
+<p class="font-label-sm text-label-sm text-on-surface-variant">© 2024 InviteYou.ca Business Solutions. All rights reserved.</p>
+<div class="flex flex-wrap justify-center gap-6">
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Privacy Policy</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Terms of Service</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Cookie Policy</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Sitemap</a>
+</div>
+</div>
+</div>
+</footer>
+<script>
+        // Simple Intersection Observer for reveal animations
+        const observerOptions = {
+            threshold: 0.1
+        };
+
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('opacity-100');
+                    entry.target.classList.remove('opacity-0', 'translate-y-10');
+                }
+            });
+        }, observerOptions);
+
+        document.querySelectorAll('.glass-card').forEach(el => {
+            el.classList.add('transition-all', 'duration-700', 'opacity-0', 'translate-y-10');
+            observer.observe(el);
+        });
+    </script>
+
+
+
+
+
+
+</body></html>

--- a/marketing/build_site.py
+++ b/marketing/build_site.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Assemble the InviteYou.ca multi-page site from the Stitch source folders.
+
+Copies each source `code.html` to a clean filename in this directory and rewires
+all internal navigation: brand -> home, nav/footer labels -> their pages,
+CTAs (Get Started / Book Consultation / etc.) -> contact.
+"""
+import re
+from pathlib import Path
+
+SRC = Path.home() / "Downloads" / "stitch_inviteyou_dynamic_business_solution"
+OUT = Path(__file__).resolve().parent
+
+# source folder -> destination filename
+PAGES = {
+    "home_inviteyou.ca_business_solutions": "index.html",
+    "services_inviteyou.ca_business_solutions": "services.html",
+    "solutions_inviteyou.ca_tailored_business_solutions": "solutions.html",
+    "process_inviteyou.ca_methodology": "process.html",
+    "portfolio_inviteyou.ca_case_studies": "portfolio.html",
+    "about_us_inviteyou.ca_mission_team": "about.html",
+    "contact_us_inviteyou.ca_project_inquiry": "contact.html",
+    "careers_join_the_inviteyou.ca_team": "careers.html",
+    "faq_frequently_asked_questions_inviteyou.ca": "faq.html",
+}
+
+# normalized anchor text -> destination file
+LABEL_MAP = {
+    "home": "index.html",
+    "solutions": "solutions.html",
+    "services": "services.html",
+    "process": "process.html",
+    "portfolio": "portfolio.html",
+    "view portfolio": "portfolio.html",
+    "view all work": "portfolio.html",
+    "view case studies": "portfolio.html",
+    "about": "about.html",
+    "about us": "about.html",
+    "our story": "about.html",
+    "contact": "contact.html",
+    "contact us": "contact.html",
+    "get in touch": "contact.html",
+    "start a project": "contact.html",
+    "start a conversation": "contact.html",
+    "book consultation": "contact.html",
+    "book a consultation": "contact.html",
+    "get started": "contact.html",
+    "careers": "careers.html",
+    "join our team": "careers.html",
+    "view open roles": "careers.html",
+    "view all positions": "careers.html",
+    "faq": "faq.html",
+    "faqs": "faq.html",
+    "inviteyou.ca": "index.html",
+    # Footer service columns
+    "custom web apps": "services.html",
+    "mobile development": "services.html",
+    "ai integration": "services.html",
+    "saas systems": "services.html",
+    "b2b platforms": "services.html",
+    "custom tech": "services.html",
+    "digital strategy": "services.html",
+    "ux/ui design": "services.html",
+    # Footer industry columns
+    "fintech": "solutions.html",
+    "finance": "solutions.html",
+    "retail": "solutions.html",
+    "tech & saas": "solutions.html",
+    "healthcare": "solutions.html",
+    "logistics": "solutions.html",
+}
+
+
+def norm(text: str) -> str:
+    t = text.replace("&amp;", "&")
+    t = re.sub(r"\s+", " ", t).strip().lower()
+    t = t.strip(" \u2192->\u2013\u2014.!")  # strip arrows/punctuation
+    return t.strip()
+
+
+def rewrite_anchor(m: re.Match) -> str:
+    pre, mid, label = m.group(1), m.group(2), m.group(3)
+    dest = LABEL_MAP.get(norm(label))
+    if dest:
+        return f'{pre}"{dest}"{mid}{label}'
+    return m.group(0)
+
+
+# Matches <a ... href="#"> LABEL   (label = text up to next tag)
+ANCHOR_RE = re.compile(r'(<a\b[^>]*?href=)"#"([^>]*>)(\s*[^<]*)')
+
+# Brand text as a <div> -> convert to link to home
+BRAND_DIV_RE = re.compile(r'<div([^>]*)>(\s*InviteYou\.ca\s*)</div>')
+
+# "Get Started" style <button> in headers -> wrap with a contact link
+GET_STARTED_BTN_RE = re.compile(
+    r'(<button\b[^>]*>)(\s*Get Started\s*)(</button>)', re.S)
+
+
+def transform(html: str) -> str:
+    html = ANCHOR_RE.sub(rewrite_anchor, html)
+    html = BRAND_DIV_RE.sub(
+        r'<a href="index.html"\1 style="cursor:pointer">\2</a>', html)
+    html = GET_STARTED_BTN_RE.sub(
+        r'<a href="contact.html">\1\2\3</a>', html)
+    return html
+
+
+def main():
+    count = 0
+    for folder, dest in PAGES.items():
+        src_file = SRC / folder / "code.html"
+        if not src_file.exists():
+            print(f"!! missing {src_file}")
+            continue
+        html = src_file.read_text(encoding="utf-8")
+        (OUT / dest).write_text(transform(html), encoding="utf-8")
+        count += 1
+        print(f"  {folder}/code.html -> {dest}")
+    print(f"Wrote {count} pages to {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketing/careers.html
+++ b/marketing/careers.html
@@ -1,0 +1,384 @@
+<!DOCTYPE html><html class="scroll-smooth" lang="en"><head>
+<meta charset="utf-8">
+<meta content="width=device-width, initial-scale=1.0" name="viewport">
+<title>Careers | InviteYou.ca</title>
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;600;700&amp;family=Inter:wght@400;500&amp;family=JetBrains+Mono:wght@500&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet">
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<script id="tailwind-config">
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            "colors": {
+                    "on-tertiary-fixed": "#410007",
+                    "outline-variant": "#c2c6d9",
+                    "tertiary-fixed": "#ffdad8",
+                    "on-secondary": "#ffffff",
+                    "inverse-surface": "#2d3135",
+                    "surface-tint": "#0053da",
+                    "error-container": "#ffdad6",
+                    "tertiary-fixed-dim": "#ffb3b1",
+                    "secondary-fixed-dim": "#44dfab",
+                    "on-surface": "#181c20",
+                    "tertiary": "#94393b",
+                    "on-secondary-fixed-variant": "#00513a",
+                    "surface-variant": "#e0e3e8",
+                    "inverse-on-surface": "#eef1f6",
+                    "on-secondary-fixed": "#002116",
+                    "on-secondary-container": "#007354",
+                    "on-primary": "#ffffff",
+                    "on-error-container": "#93000a",
+                    "ghost-white": "#F8F9FA",
+                    "secondary": "#006c4f",
+                    "on-error": "#ffffff",
+                    "soft-teal": "#20C997",
+                    "surface-subtle": "#FBF2F2",
+                    "on-primary-fixed-variant": "#003ea8",
+                    "background": "#f7f9ff",
+                    "outline": "#737687",
+                    "surface-container": "#ebeef3",
+                    "secondary-container": "#67fcc6",
+                    "surface-container-highest": "#e0e3e8",
+                    "surface-container-high": "#e5e8ee",
+                    "inverse-primary": "#b4c5ff",
+                    "on-tertiary-fixed-variant": "#7f292c",
+                    "on-primary-fixed": "#00174b",
+                    "primary-fixed": "#dbe1ff",
+                    "error": "#ba1a1a",
+                    "electric-blue": "#0062FF",
+                    "primary-fixed-dim": "#b4c5ff",
+                    "surface-bright": "#f7f9ff",
+                    "tertiary-container": "#b35052",
+                    "surface-container-lowest": "#ffffff",
+                    "surface-dim": "#d7dadf",
+                    "primary": "#004cca",
+                    "primary-container": "#0062ff",
+                    "secondary-container": "#67fcc6",
+                    "on-background": "#181c20",
+                    "surface": "#f7f9ff",
+                    "on-primary-container": "#f3f3ff",
+                    "on-tertiary-container": "#fff1ef",
+                    "surface-container-low": "#f1f4f9",
+                    "on-surface-variant": "#424656",
+                    "on-tertiary": "#ffffff"
+            },
+            "borderRadius": {
+                    "DEFAULT": "0.25rem",
+                    "lg": "0.5rem",
+                    "xl": "0.75rem",
+                    "full": "9999px"
+            },
+            "spacing": {
+                    "margin-mobile": "16px",
+                    "margin-desktop": "64px",
+                    "unit": "4px",
+                    "max-width": "1280px",
+                    "gutter": "24px"
+            },
+            "fontFamily": {
+                    "label-md": ["JetBrains Mono"],
+                    "headline-xl": ["Hanken Grotesk"],
+                    "headline-lg": ["Hanken Grotesk"],
+                    "body-md": ["Inter"],
+                    "headline-lg-mobile": ["Hanken Grotesk"],
+                    "label-sm": ["JetBrains Mono"],
+                    "headline-md": ["Hanken Grotesk"],
+                    "body-lg": ["Inter"]
+            },
+            "fontSize": {
+                    "label-md": ["14px", {"lineHeight": "20px", "letterSpacing": "0.05em", "fontWeight": "500"}],
+                    "headline-xl": ["64px", {"lineHeight": "72px", "letterSpacing": "-0.02em", "fontWeight": "700"}],
+                    "headline-lg": ["48px", {"lineHeight": "56px", "letterSpacing": "-0.01em", "fontWeight": "600"}],
+                    "body-md": ["16px", {"lineHeight": "24px", "fontWeight": "400"}],
+                    "headline-lg-mobile": ["32px", {"lineHeight": "40px", "fontWeight": "600"}],
+                    "label-sm": ["12px", {"lineHeight": "16px", "letterSpacing": "0.05em", "fontWeight": "500"}],
+                    "headline-md": ["32px", {"lineHeight": "40px", "fontWeight": "600"}],
+                    "body-lg": ["18px", {"lineHeight": "28px", "fontWeight": "400"}]
+            }
+          },
+        },
+      }
+    </script>
+<style>
+        .material-symbols-outlined {
+            font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+            display: inline-block;
+            vertical-align: middle;
+        }
+        .glass-card {
+            background: rgba(255, 255, 255, 0.7);
+            backdrop-filter: blur(12px);
+            border: 1px solid rgba(233, 236, 237, 0.5);
+        }
+        .hero-gradient {
+            background: radial-gradient(circle at 70% 30%, rgba(0, 98, 255, 0.05) 0%, transparent 50%),
+                        radial-gradient(circle at 10% 80%, rgba(32, 201, 151, 0.05) 0%, transparent 50%);
+        }
+    </style>
+</head>
+<body class="bg-surface text-on-surface font-body-md antialiased overflow-x-hidden">
+<!-- TopNavBar -->
+<header class="fixed top-0 left-0 w-full z-50 bg-surface/70 backdrop-blur-xl shadow-sm">
+<div class="flex justify-between items-center max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-4">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary tracking-tight" style="cursor:pointer">InviteYou.ca</a>
+<nav class="hidden md:flex items-center space-x-8">
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="services.html">Services</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="solutions.html">Solutions</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="process.html">Process</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="portfolio.html">Portfolio</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="about.html">About</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="contact.html">Contact</a>
+</nav>
+<a href="contact.html"><button class="bg-primary-container text-on-primary-container px-6 py-2.5 rounded-full font-label-md text-label-md hover:scale-105 hover:shadow-md transition-all duration-200 active:scale-95">Get Started</button></a>
+</div>
+</header>
+<main class="pt-20">
+<!-- Hero Section -->
+<section class="relative min-h-[819px] flex items-center hero-gradient overflow-hidden px-margin-mobile md:px-margin-desktop">
+<div class="max-w-max-width mx-auto grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+<div class="z-10">
+<span class="inline-block px-4 py-1 rounded-full bg-primary-fixed text-on-primary-fixed font-label-sm text-label-sm mb-6">WE ARE HIRING</span>
+<h1 class="font-headline-xl text-[48px] md:text-headline-xl text-on-surface mb-6 leading-tight">
+                        Join Our Mission to <span class="text-electric-blue">Transform Business</span>
+</h1>
+<p class="font-body-lg text-body-lg text-on-surface-variant mb-10 max-w-xl">
+                        At InviteYou.ca, we're building the future of digital engagement. We look for thinkers, creators, and doers who want to redefine how brands connect with their audiences.
+                    </p>
+<div class="flex flex-wrap gap-4">
+<a class="bg-electric-blue text-white px-8 py-4 rounded-xl font-label-md text-label-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1" href="#openings">View Openings</a>
+<a class="border border-outline text-on-surface-variant px-8 py-4 rounded-xl font-label-md text-label-md hover:bg-surface-container-low transition-all" href="#culture">Our Culture</a>
+</div>
+</div>
+<div class="relative hidden lg:block">
+<div class="aspect-square rounded-3xl overflow-hidden shadow-2xl relative z-10 transform rotate-3 hover:rotate-0 transition-transform duration-700">
+<img class="w-full h-full object-cover" data-alt="A bright, modern office space with large windows and lush indoor plants. Diverse professionals are collaborating around a minimalist white table with sleek laptops and high-tech displays. The lighting is soft and airy, emphasizing a high-trust, collaborative B2B atmosphere with electric blue accents and a minimalist clean aesthetic." src="https://lh3.googleusercontent.com/aida-public/AB6AXuBx0lHh7cntG-3FuZLByFk4y4p5vn6K10HH-n_4qdOEdT1GrJskaJppaELn5iIO_qNHEpI9eTV0dCIyAENqafBq4ouc-ySgCKxoRxqteiAAHQ6gaIuruwowsxgDskHYQ4sfDk5_pNdRboZM0SaB9cRSJ7rWtgJnsst2Yur-13esxRSIYkG5d2K5Ww23RtlzZBh9G6f_lDxMwEkjaryXFp6pVo-vrQIVHVbiaP6TvatyoFeydtVNWY-tw_UwtJWDaDuzfRcEgAZIKjM">
+</div>
+<div class="absolute -top-12 -right-12 w-64 h-64 bg-secondary-container/20 rounded-full blur-3xl"></div>
+<div class="absolute -bottom-12 -left-12 w-48 h-48 bg-primary-container/20 rounded-full blur-3xl"></div>
+</div>
+</div>
+</section>
+<!-- Culture & Values -->
+<section class="py-32 bg-surface-container-lowest" id="culture">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop">
+<div class="text-center mb-20">
+<h2 class="font-headline-lg text-headline-lg text-on-surface mb-4">Values That Drive Us</h2>
+<p class="text-on-surface-variant max-w-2xl mx-auto font-body-md text-body-md">We believe that a great product is a reflection of a great team. Our core values aren't just posters—they're the way we work every day.</p>
+</div>
+<div class="grid grid-cols-1 md:grid-cols-3 gap-gutter">
+<!-- Value 1 -->
+<div class="p-10 rounded-2xl bg-surface-bright border border-outline-variant/30 hover:shadow-xl hover:-translate-y-2 transition-all duration-300">
+<div class="w-14 h-14 rounded-xl bg-primary/10 text-primary flex items-center justify-center mb-6">
+<span class="material-symbols-outlined text-3xl" data-icon="rocket_launch">rocket_launch</span>
+</div>
+<h3 class="font-headline-md text-headline-md mb-4 text-on-surface">Radical Innovation</h3>
+<p class="text-on-surface-variant font-body-md">We don't settle for "best practice." We search for the next frontier in digital solutions and push boundaries together.</p>
+</div>
+<!-- Value 2 -->
+<div class="p-10 rounded-2xl bg-surface-bright border border-outline-variant/30 hover:shadow-xl hover:-translate-y-2 transition-all duration-300">
+<div class="w-14 h-14 rounded-xl bg-soft-teal/10 text-secondary flex items-center justify-center mb-6">
+<span class="material-symbols-outlined text-3xl" data-icon="handshake">handshake</span>
+</div>
+<h3 class="font-headline-md text-headline-md mb-4 text-on-surface">Trusted Reliability</h3>
+<p class="text-on-surface-variant font-body-md">Trust is our currency. We build reliable systems and maintain transparent relationships with our team and clients.</p>
+</div>
+<!-- Value 3 -->
+<div class="p-10 rounded-2xl bg-surface-bright border border-outline-variant/30 hover:shadow-xl hover:-translate-y-2 transition-all duration-300">
+<div class="w-14 h-14 rounded-xl bg-tertiary-container/10 text-tertiary flex items-center justify-center mb-6">
+<span class="material-symbols-outlined text-3xl" data-icon="diversity_3">diversity_3</span>
+</div>
+<h3 class="font-headline-md text-headline-md mb-4 text-on-surface">Diverse Perspectives</h3>
+<p class="text-on-surface-variant font-body-md">Unique backgrounds lead to unique solutions. We cultivate an environment where every voice is heard and valued.</p>
+</div>
+</div>
+</div>
+</section>
+<!-- Employee Benefits -->
+<section class="py-32 bg-surface">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop">
+<div class="flex flex-col lg:flex-row gap-16 items-center">
+<div class="lg:w-1/2">
+<div class="w-full aspect-[4/3] rounded-3xl bg-cover bg-center shadow-lg relative overflow-hidden group" data-alt="A group of energetic young professionals laughing and discussing ideas in a vibrant breakout area with modular furniture. High-end coffee bar in the background, warm ambient lighting, and modern minimalist decor. The scene is bright and professional, projecting an aura of success and well-being in a modern tech company." style="background-image: url('https://lh3.googleusercontent.com/aida-public/AB6AXuBYjGUJLsV-zhZPl3gToiXBnbPuer-7ToYwPIzQcRe486crQMT9vchoOMLVTbYK9udGLaJ2uPjtXrrbuENc84AZpy5pTdXoFVxytwGNMeM_4O5wP7V9srCj_irFTJHkgNUSYzKRHRf-36QRd4jAc94l6nD442cMQZzH57ttIFBFK8bEPMChKePineqls-EQbgt0aUqBdSfRF63NcVBGH-rETtA7auw6PCUTTet2e3GX4ae83zANr-mkhPlJSaun3EDNLIwGrJnYYMA')">
+<div class="absolute inset-0 bg-electric-blue/10 group-hover:bg-transparent transition-colors duration-500"></div>
+</div>
+</div>
+<div class="lg:w-1/2">
+<h2 class="font-headline-lg text-headline-lg text-on-surface mb-8">More Than Just a Paycheck</h2>
+<div class="space-y-6">
+<div class="flex items-start gap-4">
+<span class="material-symbols-outlined text-electric-blue mt-1" data-icon="check_circle" data-weight="fill" style="font-variation-settings: 'FILL' 1;">check_circle</span>
+<div>
+<h4 class="font-bold text-on-surface">Remote-First Culture</h4>
+<p class="text-on-surface-variant">Work from where you feel most productive with our fully supported remote work setup.</p>
+</div>
+</div>
+<div class="flex items-start gap-4">
+<span class="material-symbols-outlined text-electric-blue mt-1" data-icon="check_circle" data-weight="fill" style="font-variation-settings: 'FILL' 1;">check_circle</span>
+<div>
+<h4 class="font-bold text-on-surface">Health &amp; Wellness</h4>
+<p class="text-on-surface-variant">Comprehensive health, dental, and vision insurance plus a monthly wellness stipend.</p>
+</div>
+</div>
+<div class="flex items-start gap-4">
+<span class="material-symbols-outlined text-electric-blue mt-1" data-icon="check_circle" data-weight="fill" style="font-variation-settings: 'FILL' 1;">check_circle</span>
+<div>
+<h4 class="font-bold text-on-surface">Learning Budget</h4>
+<p class="text-on-surface-variant">$2,000 annual budget for courses, conferences, and professional development.</p>
+</div>
+</div>
+<div class="flex items-start gap-4">
+<span class="material-symbols-outlined text-electric-blue mt-1" data-icon="check_circle" data-weight="fill" style="font-variation-settings: 'FILL' 1;">check_circle</span>
+<div>
+<h4 class="font-bold text-on-surface">Unlimited PTO</h4>
+<p class="text-on-surface-variant">We trust you to manage your time. Take the rest you need to stay inspired.</p>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+<!-- Current Openings (Bento/Card Grid) -->
+<section class="py-32 bg-surface-container-low" id="openings">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop">
+<div class="flex flex-col md:flex-row justify-between items-end mb-16 gap-6">
+<div>
+<h2 class="font-headline-lg text-headline-lg text-on-surface mb-2">Current Openings</h2>
+<p class="text-on-surface-variant font-body-md">Find the role where you'll make the biggest impact.</p>
+</div>
+<div class="flex gap-4">
+<select class="rounded-full border-outline-variant bg-surface-container-lowest text-on-surface-variant font-label-sm px-6 py-2">
+<option>All Departments</option>
+<option>Design</option>
+<option>Engineering</option>
+<option>Sales</option>
+</select>
+</div>
+</div>
+<div class="grid grid-cols-1 gap-6">
+<!-- Job Card 1 -->
+<div class="glass-card group p-8 rounded-2xl flex flex-col md:flex-row justify-between items-center transition-all duration-300 hover:shadow-2xl hover:scale-[1.01]">
+<div class="mb-6 md:mb-0">
+<div class="flex gap-2 mb-3">
+<span class="px-3 py-1 rounded-full bg-primary/10 text-primary font-label-sm text-[10px] uppercase">Design</span>
+<span class="px-3 py-1 rounded-full bg-on-surface-variant/10 text-on-surface-variant font-label-sm text-[10px] uppercase">Remote</span>
+</div>
+<h3 class="font-headline-md text-headline-md text-on-surface mb-1">Senior UI/UX Designer</h3>
+<p class="text-on-surface-variant">Lead the visual evolution of our core digital experience platforms.</p>
+</div>
+<div class="flex items-center gap-6">
+<span class="text-on-surface-variant font-label-md">$120k — $160k</span>
+<button class="bg-primary text-on-primary px-8 py-3 rounded-xl font-label-md transition-all group-hover:bg-electric-blue">Apply Now</button>
+</div>
+</div>
+<!-- Job Card 2 -->
+<div class="glass-card group p-8 rounded-2xl flex flex-col md:flex-row justify-between items-center transition-all duration-300 hover:shadow-2xl hover:scale-[1.01]">
+<div class="mb-6 md:mb-0">
+<div class="flex gap-2 mb-3">
+<span class="px-3 py-1 rounded-full bg-secondary/10 text-secondary font-label-sm text-[10px] uppercase">Solutions</span>
+<span class="px-3 py-1 rounded-full bg-on-surface-variant/10 text-on-surface-variant font-label-sm text-[10px] uppercase">Hybrid (Toronto)</span>
+</div>
+<h3 class="font-headline-md text-headline-md text-on-surface mb-1">Solutions Consultant</h3>
+<p class="text-on-surface-variant">Bridge the gap between complex client needs and our innovative technology.</p>
+</div>
+<div class="flex items-center gap-6">
+<span class="text-on-surface-variant font-label-md">$90k — $130k</span>
+<button class="bg-primary text-on-primary px-8 py-3 rounded-xl font-label-md transition-all group-hover:bg-electric-blue">Apply Now</button>
+</div>
+</div>
+<!-- Job Card 3 -->
+<div class="glass-card group p-8 rounded-2xl flex flex-col md:flex-row justify-between items-center transition-all duration-300 hover:shadow-2xl hover:scale-[1.01]">
+<div class="mb-6 md:mb-0">
+<div class="flex gap-2 mb-3">
+<span class="px-3 py-1 rounded-full bg-tertiary/10 text-tertiary font-label-sm text-[10px] uppercase">Engineering</span>
+<span class="px-3 py-1 rounded-full bg-on-surface-variant/10 text-on-surface-variant font-label-sm text-[10px] uppercase">Remote</span>
+</div>
+<h3 class="font-headline-md text-headline-md text-on-surface mb-1">Full Stack Developer (Next.js)</h3>
+<p class="text-on-surface-variant">Build scalable, high-performance web applications for global B2B clients.</p>
+</div>
+<div class="flex items-center gap-6">
+<span class="text-on-surface-variant font-label-md">$110k — $150k</span>
+<button class="bg-primary text-on-primary px-8 py-3 rounded-xl font-label-md transition-all group-hover:bg-electric-blue">Apply Now</button>
+</div>
+</div>
+</div>
+<div class="mt-16 text-center">
+<p class="text-on-surface-variant mb-6 font-body-md">Don't see a role that fits? We're always looking for great talent.</p>
+<a class="text-electric-blue font-bold hover:underline underline-offset-4" href="mailto:careers@inviteyou.ca">Send us an open application →</a>
+</div>
+</div>
+</section>
+<!-- CTA Section -->
+<section class="py-32 relative overflow-hidden bg-inverse-surface">
+<div class="absolute inset-0 opacity-10">
+<div class="absolute top-0 left-0 w-full h-full bg-[radial-gradient(#fff_1px,transparent_1px)] [background-size:20px_20px]"></div>
+</div>
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop text-center relative z-10">
+<h2 class="font-headline-lg text-headline-lg text-inverse-on-surface mb-6">Ready to make your mark?</h2>
+<p class="text-outline-variant max-w-xl mx-auto mb-10 text-body-lg font-body-lg">Join a team that values your growth as much as the company's. Let's build something extraordinary together.</p>
+<div class="flex justify-center gap-6">
+<button class="bg-white text-primary px-10 py-4 rounded-xl font-bold hover:scale-105 transition-transform">Explore All Roles</button>
+</div>
+</div>
+</section>
+</main>
+<!-- Footer -->
+<footer class="w-full bg-surface-container-lowest border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-16 grid grid-cols-2 md:grid-cols-4 gap-8">
+<div class="col-span-2 md:col-span-1">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary" style="cursor:pointer">InviteYou.ca</a>
+<p class="font-body-md text-body-md text-on-surface-variant mt-4 max-w-xs">Architecting custom business solutions with high-tech innovation and institutional reliability.</p>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Company</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="about.html">About</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="careers.html">Careers</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Contact</a></li>
+</ul>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Expertise</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="services.html">Services</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="solutions.html">Solutions</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="process.html">Process</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="portfolio.html">Portfolio</a></li>
+</ul>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Support</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="faq.html">FAQ</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Contact</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Get Started</a></li>
+</ul>
+</div>
+</div>
+<div class="border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-6 flex flex-col md:flex-row justify-between items-center gap-4">
+<p class="font-label-sm text-label-sm text-on-surface-variant">© 2024 InviteYou.ca Business Solutions. All rights reserved.</p>
+<div class="flex flex-wrap justify-center gap-6">
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Privacy Policy</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Terms of Service</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Cookie Policy</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Sitemap</a>
+</div>
+</div>
+</div>
+</footer>
+<script>
+        // Micro-interactions and floating effects
+        document.querySelectorAll('.glass-card').forEach(card => {
+            card.addEventListener('mousemove', (e) => {
+                const rect = card.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                card.style.setProperty('--mouse-x', `${x}px`);
+                card.style.setProperty('--mouse-y', `${y}px`);
+            });
+        });
+    </script>
+</body></html>

--- a/marketing/connect_nav.py
+++ b/marketing/connect_nav.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Standardize the shared header + footer across all InviteYou.ca pages so every
+page is reachable (fully connected navigation)."""
+import re
+from pathlib import Path
+
+OUT = Path(__file__).resolve().parent
+
+# dest file -> active nav label (None = no active top-nav item)
+ACTIVE = {
+    "index.html": None,
+    "services.html": "Services",
+    "solutions.html": "Solutions",
+    "process.html": "Process",
+    "portfolio.html": "Portfolio",
+    "about.html": "About",
+    "contact.html": "Contact",
+    "careers.html": None,
+    "faq.html": None,
+}
+
+NAV = [
+    ("Services", "services.html"),
+    ("Solutions", "solutions.html"),
+    ("Process", "process.html"),
+    ("Portfolio", "portfolio.html"),
+    ("About", "about.html"),
+    ("Contact", "contact.html"),
+]
+
+INACTIVE_CLS = ("text-on-surface-variant hover:text-primary transition-colors "
+                "duration-200 font-label-md text-label-md")
+ACTIVE_CLS = ("text-primary border-b-2 border-primary pb-1 font-semibold "
+              "font-label-md text-label-md")
+
+
+def header_html(active):
+    links = []
+    for label, href in NAV:
+        cls = ACTIVE_CLS if label == active else INACTIVE_CLS
+        links.append(f'<a class="{cls}" href="{href}">{label}</a>')
+    links_html = "\n".join(links)
+    return f'''<header class="fixed top-0 left-0 w-full z-50 bg-surface/70 backdrop-blur-xl shadow-sm">
+<div class="flex justify-between items-center max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-4">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary tracking-tight" style="cursor:pointer">InviteYou.ca</a>
+<nav class="hidden md:flex items-center space-x-8">
+{links_html}
+</nav>
+<a href="contact.html"><button class="bg-primary-container text-on-primary-container px-6 py-2.5 rounded-full font-label-md text-label-md hover:scale-105 hover:shadow-md transition-all duration-200 active:scale-95">Get Started</button></a>
+</div>
+</header>'''
+
+
+FLINK = "text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md"
+FLEGAL = "text-on-surface-variant hover:text-primary transition-all text-sm font-body-md"
+
+
+def _fcol(title, items):
+    lis = "\n".join(
+        f'<li><a class="{FLINK}" href="{href}">{label}</a></li>'
+        for label, href in items)
+    return f'''<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">{title}</h4>
+<ul class="space-y-3">
+{lis}
+</ul>
+</div>'''
+
+
+FOOTER = f'''<footer class="w-full bg-surface-container-lowest border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-16 grid grid-cols-2 md:grid-cols-4 gap-8">
+<div class="col-span-2 md:col-span-1">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary" style="cursor:pointer">InviteYou.ca</a>
+<p class="font-body-md text-body-md text-on-surface-variant mt-4 max-w-xs">Architecting custom business solutions with high-tech innovation and institutional reliability.</p>
+</div>
+{_fcol("Company", [("About", "about.html"), ("Careers", "careers.html"), ("Contact", "contact.html")])}
+{_fcol("Expertise", [("Services", "services.html"), ("Solutions", "solutions.html"), ("Process", "process.html"), ("Portfolio", "portfolio.html")])}
+{_fcol("Support", [("FAQ", "faq.html"), ("Contact", "contact.html"), ("Get Started", "contact.html")])}
+</div>
+<div class="border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-6 flex flex-col md:flex-row justify-between items-center gap-4">
+<p class="font-label-sm text-label-sm text-on-surface-variant">© 2024 InviteYou.ca Business Solutions. All rights reserved.</p>
+<div class="flex flex-wrap justify-center gap-6">
+<a class="{FLEGAL}" href="#">Privacy Policy</a>
+<a class="{FLEGAL}" href="#">Terms of Service</a>
+<a class="{FLEGAL}" href="#">Cookie Policy</a>
+<a class="{FLEGAL}" href="#">Sitemap</a>
+</div>
+</div>
+</div>
+</footer>'''
+
+HEADER_RE = re.compile(r'<header\b[^>]*>.*?</header>', re.S)
+FAQ_NAV_RE = re.compile(r'<nav class="fixed top-0[^"]*"[^>]*>.*?</nav>', re.S)
+FOOTER_RE = re.compile(r'<footer\b[^>]*>.*?</footer>', re.S)
+
+
+def main():
+    for fname, active in ACTIVE.items():
+        p = OUT / fname
+        html = p.read_text(encoding="utf-8")
+        hdr = header_html(active)
+        if HEADER_RE.search(html):
+            html, n = HEADER_RE.subn(hdr, html, count=1)
+        else:  # faq.html uses a bare fixed <nav> as its header
+            html, n = FAQ_NAV_RE.subn(hdr, html, count=1)
+        fn = FOOTER_RE.subn(FOOTER, html, count=1)
+        html, nf = fn
+        p.write_text(html, encoding="utf-8")
+        print(f"  {fname}: header={n} footer={nf} active={active}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketing/contact.html
+++ b/marketing/contact.html
@@ -1,0 +1,335 @@
+<!DOCTYPE html><html class="scroll-smooth" lang="en"><head>
+<meta charset="utf-8">
+<meta content="width=device-width, initial-scale=1.0" name="viewport">
+<title>Contact Us | InviteYou.ca</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;600;700;800&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@500&amp;family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@100..900&amp;family=Inter:wght@100..900&amp;family=JetBrains+Mono:wght@100..900&amp;display=swap" rel="stylesheet">
+<script id="tailwind-config">
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            "colors": {
+                    "on-tertiary-fixed": "#410007",
+                    "outline-variant": "#c2c6d9",
+                    "tertiary-fixed": "#ffdad8",
+                    "on-secondary": "#ffffff",
+                    "inverse-surface": "#2d3135",
+                    "surface-tint": "#0053da",
+                    "error-container": "#ffdad6",
+                    "tertiary-fixed-dim": "#ffb3b1",
+                    "secondary-fixed-dim": "#44dfab",
+                    "on-surface": "#181c20",
+                    "tertiary": "#94393b",
+                    "on-secondary-fixed-variant": "#00513a",
+                    "surface-variant": "#e0e3e8",
+                    "inverse-on-surface": "#eef1f6",
+                    "on-secondary-fixed": "#002116",
+                    "on-secondary-container": "#007354",
+                    "on-primary": "#ffffff",
+                    "on-error-container": "#93000a",
+                    "ghost-white": "#F8F9FA",
+                    "secondary": "#006c4f",
+                    "on-error": "#ffffff",
+                    "soft-teal": "#20C997",
+                    "surface-subtle": "#FBF2F2",
+                    "on-primary-fixed-variant": "#003ea8",
+                    "background": "#f7f9ff",
+                    "outline": "#737687",
+                    "surface-container": "#ebeef3",
+                    "secondary-container": "#67fcc6",
+                    "surface-container-highest": "#e0e3e8",
+                    "surface-container-high": "#e5e8ee",
+                    "inverse-primary": "#b4c5ff",
+                    "on-tertiary-fixed-variant": "#7f292c",
+                    "on-primary-fixed": "#00174b",
+                    "primary-fixed": "#dbe1ff",
+                    "error": "#ba1a1a",
+                    "electric-blue": "#0062FF",
+                    "primary-fixed-dim": "#b4c5ff",
+                    "surface-bright": "#f7f9ff",
+                    "tertiary-container": "#b35052",
+                    "surface-container-lowest": "#ffffff",
+                    "surface-dim": "#d7dadf",
+                    "primary": "#004cca",
+                    "primary-container": "#0062ff",
+                    "secondary-container": "#67fcc6",
+                    "on-background": "#181c20",
+                    "surface": "#f7f9ff",
+                    "on-primary-container": "#f3f3ff",
+                    "on-tertiary-container": "#fff1ef",
+                    "surface-container-low": "#f1f4f9",
+                    "on-surface-variant": "#424656",
+                    "on-tertiary": "#ffffff"
+            },
+            "borderRadius": {
+                    "DEFAULT": "0.25rem",
+                    "lg": "0.5rem",
+                    "xl": "0.75rem",
+                    "full": "9999px"
+            },
+            "spacing": {
+                    "margin-mobile": "16px",
+                    "margin-desktop": "64px",
+                    "unit": "4px",
+                    "max-width": "1280px",
+                    "gutter": "24px"
+            },
+            "fontFamily": {
+                    "label-md": ["JetBrains Mono"],
+                    "headline-xl": ["Hanken Grotesk"],
+                    "headline-lg": ["Hanken Grotesk"],
+                    "body-md": ["Inter"],
+                    "headline-lg-mobile": ["Hanken Grotesk"],
+                    "label-sm": ["JetBrains Mono"],
+                    "headline-md": ["Hanken Grotesk"],
+                    "body-lg": ["Inter"]
+            },
+            "fontSize": {
+                    "label-md": ["14px", {"lineHeight": "20px", "letterSpacing": "0.05em", "fontWeight": "500"}],
+                    "headline-xl": ["64px", {"lineHeight": "72px", "letterSpacing": "-0.02em", "fontWeight": "700"}],
+                    "headline-lg": ["48px", {"lineHeight": "56px", "letterSpacing": "-0.01em", "fontWeight": "600"}],
+                    "body-md": ["16px", {"lineHeight": "24px", "fontWeight": "400"}],
+                    "headline-lg-mobile": ["32px", {"lineHeight": "40px", "fontWeight": "600"}],
+                    "label-sm": ["12px", {"lineHeight": "16px", "letterSpacing": "0.05em", "fontWeight": "500"}],
+                    "headline-md": ["32px", {"lineHeight": "40px", "fontWeight": "600"}],
+                    "body-lg": ["18px", {"lineHeight": "28px", "fontWeight": "400"}]
+            }
+          },
+        },
+      }
+    </script>
+<style>
+        .material-symbols-outlined {
+            font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+            display: inline-block;
+            vertical-align: middle;
+        }
+        .glass-card {
+            background: rgba(255, 255, 255, 0.7);
+            backdrop-filter: blur(12px);
+            border: 1px solid rgba(233, 236, 239, 1);
+        }
+        .input-glow:focus {
+            box-shadow: 0 0 0 4px rgba(0, 98, 255, 0.1);
+        }
+    </style>
+</head>
+<body class="bg-background text-on-surface font-body-md antialiased overflow-x-hidden">
+<!-- TopNavBar -->
+<header class="fixed top-0 left-0 w-full z-50 bg-surface/70 backdrop-blur-xl shadow-sm">
+<div class="flex justify-between items-center max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-4">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary tracking-tight" style="cursor:pointer">InviteYou.ca</a>
+<nav class="hidden md:flex items-center space-x-8">
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="services.html">Services</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="solutions.html">Solutions</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="process.html">Process</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="portfolio.html">Portfolio</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="about.html">About</a>
+<a class="text-primary border-b-2 border-primary pb-1 font-semibold font-label-md text-label-md" href="contact.html">Contact</a>
+</nav>
+<a href="contact.html"><button class="bg-primary-container text-on-primary-container px-6 py-2.5 rounded-full font-label-md text-label-md hover:scale-105 hover:shadow-md transition-all duration-200 active:scale-95">Get Started</button></a>
+</div>
+</header>
+<main class="pt-32 pb-24">
+<!-- Hero Section -->
+<section class="max-w-max-width mx-auto px-margin-desktop mb-24">
+<div class="flex flex-col items-center text-center max-w-3xl mx-auto">
+<span class="font-label-md text-label-md text-electric-blue uppercase tracking-widest mb-4">Contact Us</span>
+<h1 class="font-headline-xl text-headline-xl mb-6 leading-tight">Let’s Build Something Together</h1>
+<p class="text-body-lg text-on-surface-variant leading-relaxed">
+                    Have a vision for a digital product? We combine technical excellence with strategic design to help industry leaders scale and innovate.
+                </p>
+</div>
+</section>
+<!-- Main Grid -->
+<section class="max-w-max-width mx-auto px-margin-desktop">
+<div class="grid grid-cols-1 lg:grid-cols-12 gap-gutter items-start">
+<!-- Inquiry Form (Bento Style) -->
+<div class="lg:col-span-7 bg-surface-container-lowest rounded-2xl p-8 md:p-12 shadow-[0_40px_80px_-20px_rgba(0,0,0,0.04)] border border-outline-variant/30">
+<h2 class="font-headline-md text-headline-md mb-8">Start a Conversation</h2>
+<form class="grid grid-cols-1 md:grid-cols-2 gap-6" id="contactForm">
+<div class="flex flex-col gap-2">
+<label class="font-label-sm text-label-sm text-outline" for="name">FULL NAME</label>
+<input class="bg-ghost-white border-0 border-b-2 border-surface-variant focus:ring-0 focus:border-electric-blue transition-all duration-300 px-0 py-3 text-body-md input-glow" id="name" name="name" placeholder="John Doe" required="" type="text">
+</div>
+<div class="flex flex-col gap-2">
+<label class="font-label-sm text-label-sm text-outline" for="email">EMAIL ADDRESS</label>
+<input class="bg-ghost-white border-0 border-b-2 border-surface-variant focus:ring-0 focus:border-electric-blue transition-all duration-300 px-0 py-3 text-body-md input-glow" id="email" name="email" placeholder="john@company.com" required="" type="email">
+</div>
+<div class="flex flex-col gap-2 md:col-span-2">
+<label class="font-label-sm text-label-sm text-outline" for="industry">INDUSTRY</label>
+<select class="bg-ghost-white border-0 border-b-2 border-surface-variant focus:ring-0 focus:border-electric-blue transition-all duration-300 px-0 py-3 text-body-md appearance-none" id="industry" name="industry">
+<option value="tech">Technology</option>
+<option value="finance">Finance</option>
+<option value="healthcare">Healthcare</option>
+<option value="other">Other</option>
+</select>
+</div>
+<div class="flex flex-col gap-2 md:col-span-2">
+<label class="font-label-sm text-label-sm text-outline" for="message">YOUR MESSAGE</label>
+<textarea class="bg-ghost-white border-0 border-b-2 border-surface-variant focus:ring-0 focus:border-electric-blue transition-all duration-300 px-0 py-3 text-body-md resize-none input-glow" id="message" name="message" placeholder="Tell us about your project..." required="" rows="4"></textarea>
+</div>
+<div class="md:col-span-2 pt-4">
+<button class="w-full md:w-max bg-electric-blue text-on-primary px-10 py-4 rounded-full font-semibold hover:scale-[1.02] shadow-lg shadow-electric-blue/20 transition-all duration-300 flex items-center justify-center gap-2 group" type="submit">
+                                Send Message
+                                <span class="material-symbols-outlined group-hover:translate-x-1 transition-transform">arrow_forward</span>
+</button>
+</div>
+</form>
+</div>
+<!-- Contact Details & Map (Asymmetric Column) -->
+<div class="lg:col-span-5 flex flex-col gap-gutter">
+<!-- Contact Cards -->
+<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+<div class="glass-card p-6 rounded-xl hover:translate-y-[-4px] transition-transform duration-300">
+<div class="w-10 h-10 bg-primary-container rounded-lg flex items-center justify-center text-primary mb-4">
+<span class="material-symbols-outlined">mail</span>
+</div>
+<h3 class="font-headline-md text-[18px] mb-1">Email Us</h3>
+<p class="text-body-md text-on-surface-variant">hello@inviteyou.ca</p>
+</div>
+<div class="glass-card p-6 rounded-xl hover:translate-y-[-4px] transition-transform duration-300">
+<div class="w-10 h-10 bg-secondary-container/30 rounded-lg flex items-center justify-center text-secondary mb-4">
+<span class="material-symbols-outlined">call</span>
+</div>
+<h3 class="font-headline-md text-[18px] mb-1">Call Us</h3>
+<p class="text-body-md text-on-surface-variant">+1 (555) 000-0000</p>
+</div>
+</div>
+<!-- Map Placeholder -->
+<div class="relative w-full aspect-video rounded-2xl overflow-hidden shadow-sm group">
+<div class="absolute inset-0 bg-slate-200 animate-pulse"></div>
+<div class="absolute inset-0 z-10" data-location="Toronto, Canada">
+<img class="w-full h-full object-cover grayscale opacity-80 group-hover:grayscale-0 transition-all duration-700" data-alt="A stylized, minimalist map illustration of a modern city center like Toronto, featuring clean geometric shapes, soft gray streets, and a single vibrant electric blue pin marker. The visual style is professional and high-tech, using a light-mode color palette with subtle ambient shadows and a sense of depth. Soft morning light illuminates the scene, reinforcing a trustworthy and established corporate feel." src="https://lh3.googleusercontent.com/aida-public/AB6AXuCJH5iwGjZ0dYOH1vj6uhBaRi4mOnuM2z5roO2_uhgql-SZNp7UGyj6D0Ka-faxtVqMkRalUgVHNtau8k81zPh4zmGF7MHlw7KXXEPLGwrEMjLXuULrJt93CQbj1J4mxxCzm5br5c6oeoysugyONj37Klpm3j-Y-uVKCClIC5t48PAz9hMiFn3f4IutgOPMxNgZLOeOmgPuYrKmRPyXKG3WxlChTuKqxbio7JXd2Zsxk06Joxj0qyVD6rDZVkZxHPOHOoSvkh0ER4E">
+</div>
+<div class="absolute bottom-6 left-6 z-20 glass-card px-4 py-3 rounded-lg flex items-center gap-3">
+<span class="material-symbols-outlined text-electric-blue">location_on</span>
+<div>
+<p class="font-label-sm text-label-sm text-on-surface font-bold">HEADQUARTERS</p>
+<p class="text-[13px] text-on-surface-variant">123 Tech Hub Dr, Toronto, ON</p>
+</div>
+</div>
+</div>
+<!-- Social Links -->
+<div class="glass-card p-8 rounded-2xl flex flex-col items-center justify-center text-center">
+<p class="font-label-sm text-label-sm text-outline mb-6 tracking-widest">FOLLOW OUR JOURNEY</p>
+<div class="flex gap-6">
+<a class="w-12 h-12 rounded-full bg-surface-container flex items-center justify-center text-on-surface-variant hover:bg-electric-blue hover:text-on-primary transition-all duration-300" href="#">
+<svg class="w-5 h-5 fill-current" viewBox="0 0 24 24"><path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"></path></svg>
+</a>
+<a class="w-12 h-12 rounded-full bg-surface-container flex items-center justify-center text-on-surface-variant hover:bg-electric-blue hover:text-on-primary transition-all duration-300" href="#">
+<svg class="w-5 h-5 fill-current" viewBox="0 0 24 24"><path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.599 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z"></path></svg>
+</a>
+<a class="w-12 h-12 rounded-full bg-surface-container flex items-center justify-center text-on-surface-variant hover:bg-electric-blue hover:text-on-primary transition-all duration-300" href="#">
+<svg class="w-5 h-5 fill-current" viewBox="0 0 24 24"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"></path></svg>
+</a>
+</div>
+</div>
+</div>
+</div>
+</section>
+<!-- Dynamic Success Message (Hidden) -->
+<div class="fixed inset-0 z-[100] bg-surface/95 backdrop-blur-md flex items-center justify-center opacity-0 pointer-events-none transition-opacity duration-500" id="successOverlay">
+<div class="text-center p-12 max-w-lg">
+<div class="w-20 h-20 bg-secondary-container text-secondary rounded-full flex items-center justify-center mx-auto mb-6">
+<span class="material-symbols-outlined text-4xl">check_circle</span>
+</div>
+<h2 class="font-headline-md text-headline-md mb-4">Message Received</h2>
+<p class="text-body-lg text-on-surface-variant mb-8">We've received your inquiry and our team will get back to you within 24 hours.</p>
+<button class="bg-primary text-on-primary px-8 py-3 rounded-full font-semibold" onclick="closeSuccess()">Back to Page</button>
+</div>
+</div>
+</main>
+<!-- Footer -->
+<footer class="w-full bg-surface-container-lowest border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-16 grid grid-cols-2 md:grid-cols-4 gap-8">
+<div class="col-span-2 md:col-span-1">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary" style="cursor:pointer">InviteYou.ca</a>
+<p class="font-body-md text-body-md text-on-surface-variant mt-4 max-w-xs">Architecting custom business solutions with high-tech innovation and institutional reliability.</p>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Company</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="about.html">About</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="careers.html">Careers</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Contact</a></li>
+</ul>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Expertise</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="services.html">Services</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="solutions.html">Solutions</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="process.html">Process</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="portfolio.html">Portfolio</a></li>
+</ul>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Support</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="faq.html">FAQ</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Contact</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Get Started</a></li>
+</ul>
+</div>
+</div>
+<div class="border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-6 flex flex-col md:flex-row justify-between items-center gap-4">
+<p class="font-label-sm text-label-sm text-on-surface-variant">© 2024 InviteYou.ca Business Solutions. All rights reserved.</p>
+<div class="flex flex-wrap justify-center gap-6">
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Privacy Policy</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Terms of Service</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Cookie Policy</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Sitemap</a>
+</div>
+</div>
+</div>
+</footer>
+<script>
+        // Micro-interaction for form submission
+        const form = document.getElementById('contactForm');
+        const overlay = document.getElementById('successOverlay');
+
+        form.addEventListener('submit', (e) => {
+            e.preventDefault();
+            overlay.classList.remove('opacity-0', 'pointer-events-none');
+            overlay.classList.add('opacity-100');
+            form.reset();
+        });
+
+        function closeSuccess() {
+            overlay.classList.add('opacity-0', 'pointer-events-none');
+            overlay.classList.remove('opacity-100');
+        }
+
+        // Floating animation for glass cards
+        document.querySelectorAll('.glass-card').forEach((card, index) => {
+            card.style.animation = `floating ${3 + index}s ease-in-out infinite alternate`;
+        });
+
+        // Add small hover effects to input focus
+        const inputs = document.querySelectorAll('input, textarea, select');
+        inputs.forEach(input => {
+            input.addEventListener('focus', () => {
+                input.parentElement.querySelector('label').style.color = '#0062FF';
+            });
+            input.addEventListener('blur', () => {
+                input.parentElement.querySelector('label').style.color = '';
+            });
+        });
+    </script>
+<style>
+        @keyframes floating {
+            from { transform: translateY(0); }
+            to { transform: translateY(-8px); }
+        }
+        
+        /* Stop animation on hover to allow for manual lift-on-hover scale */
+        .glass-card:hover {
+            animation-play-state: paused !important;
+        }
+    </style>
+</body></html>

--- a/marketing/faq.html
+++ b/marketing/faq.html
@@ -1,0 +1,359 @@
+<!DOCTYPE html><html class="light" lang="en"><head>
+<meta charset="utf-8">
+<meta content="width=device-width, initial-scale=1.0" name="viewport">
+<title>FAQ - InviteYou.ca | High-Tech Digital Solutions</title>
+<!-- Fonts -->
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700;800&amp;family=Inter:wght@400;500&amp;family=JetBrains+Mono:wght@500&amp;display=swap" rel="stylesheet">
+<!-- Icons -->
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet">
+<!-- Tailwind -->
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<script id="tailwind-config">
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            "colors": {
+                    "on-tertiary-fixed": "#410007",
+                    "outline-variant": "#c2c6d9",
+                    "tertiary-fixed": "#ffdad8",
+                    "on-secondary": "#ffffff",
+                    "inverse-surface": "#2d3135",
+                    "surface-tint": "#0053da",
+                    "error-container": "#ffdad6",
+                    "tertiary-fixed-dim": "#ffb3b1",
+                    "secondary-fixed-dim": "#44dfab",
+                    "on-surface": "#181c20",
+                    "tertiary": "#94393b",
+                    "on-secondary-fixed-variant": "#00513a",
+                    "surface-variant": "#e0e3e8",
+                    "inverse-on-surface": "#eef1f6",
+                    "on-secondary-fixed": "#002116",
+                    "on-secondary-container": "#007354",
+                    "on-primary": "#ffffff",
+                    "on-error-container": "#93000a",
+                    "ghost-white": "#F8F9FA",
+                    "secondary": "#006c4f",
+                    "on-error": "#ffffff",
+                    "soft-teal": "#20C997",
+                    "surface-subtle": "#FBF2F2",
+                    "on-primary-fixed-variant": "#003ea8",
+                    "background": "#f7f9ff",
+                    "outline": "#737687",
+                    "surface-container": "#ebeef3",
+                    "secondary-container": "#67fcc6",
+                    "surface-container-highest": "#e0e3e8",
+                    "surface-container-high": "#e5e8ee",
+                    "inverse-primary": "#b4c5ff",
+                    "on-tertiary-fixed-variant": "#7f292c",
+                    "on-primary-fixed": "#00174b",
+                    "primary-fixed": "#dbe1ff",
+                    "error": "#ba1a1a",
+                    "electric-blue": "#0062FF",
+                    "primary-fixed-dim": "#b4c5ff",
+                    "surface-bright": "#f7f9ff",
+                    "tertiary-container": "#b35052",
+                    "surface-container-lowest": "#ffffff",
+                    "surface-dim": "#d7dadf",
+                    "primary": "#004cca",
+                    "primary-container": "#0062ff",
+                    "secondary-fixed": "#67fcc6",
+                    "on-background": "#181c20",
+                    "surface": "#f7f9ff",
+                    "on-primary-container": "#f3f3ff",
+                    "on-tertiary-container": "#fff1ef",
+                    "surface-container-low": "#f1f4f9",
+                    "on-surface-variant": "#424656",
+                    "on-tertiary": "#ffffff"
+            },
+            "borderRadius": {
+                    "DEFAULT": "0.25rem",
+                    "lg": "0.5rem",
+                    "xl": "0.75rem",
+                    "full": "9999px"
+            },
+            "spacing": {
+                    "margin-mobile": "16px",
+                    "margin-desktop": "64px",
+                    "unit": "4px",
+                    "max-width": "1280px",
+                    "gutter": "24px"
+            },
+            "fontFamily": {
+                    "label-md": ["JetBrains Mono"],
+                    "headline-xl": ["Hanken Grotesk"],
+                    "headline-lg": ["Hanken Grotesk"],
+                    "body-md": ["Inter"],
+                    "headline-lg-mobile": ["Hanken Grotesk"],
+                    "label-sm": ["JetBrains Mono"],
+                    "headline-md": ["Hanken Grotesk"],
+                    "body-lg": ["Inter"]
+            },
+            "fontSize": {
+                    "label-md": ["14px", {"lineHeight": "20px", "letterSpacing": "0.05em", "fontWeight": "500"}],
+                    "headline-xl": ["64px", {"lineHeight": "72px", "letterSpacing": "-0.02em", "fontWeight": "700"}],
+                    "headline-lg": ["48px", {"lineHeight": "56px", "letterSpacing": "-0.01em", "fontWeight": "600"}],
+                    "body-md": ["16px", {"lineHeight": "24px", "fontWeight": "400"}],
+                    "headline-lg-mobile": ["32px", {"lineHeight": "40px", "fontWeight": "600"}],
+                    "label-sm": ["12px", {"lineHeight": "16px", "letterSpacing": "0.05em", "fontWeight": "500"}],
+                    "headline-md": ["32px", {"lineHeight": "40px", "fontWeight": "600"}],
+                    "body-lg": ["18px", {"lineHeight": "28px", "fontWeight": "400"}]
+            }
+          },
+        },
+      }
+    </script>
+<style>
+        .glass-nav {
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+        }
+        .faq-accordion-content {
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 0.3s ease-out, padding 0.3s ease;
+        }
+        .faq-accordion-item.active .faq-accordion-content {
+            max-height: 500px;
+            padding-bottom: 24px;
+        }
+        .faq-accordion-item.active .faq-chevron {
+            transform: rotate(180deg);
+        }
+        .material-symbols-outlined {
+            font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+        }
+    </style>
+</head>
+<body class="bg-background text-on-surface font-body-md selection:bg-primary-container selection:text-on-primary-container">
+<!-- TopNavBar -->
+<header class="fixed top-0 left-0 w-full z-50 bg-surface/70 backdrop-blur-xl shadow-sm">
+<div class="flex justify-between items-center max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-4">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary tracking-tight" style="cursor:pointer">InviteYou.ca</a>
+<nav class="hidden md:flex items-center space-x-8">
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="services.html">Services</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="solutions.html">Solutions</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="process.html">Process</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="portfolio.html">Portfolio</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="about.html">About</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="contact.html">Contact</a>
+</nav>
+<a href="contact.html"><button class="bg-primary-container text-on-primary-container px-6 py-2.5 rounded-full font-label-md text-label-md hover:scale-105 hover:shadow-md transition-all duration-200 active:scale-95">Get Started</button></a>
+</div>
+</header>
+<main class="pt-32 pb-24">
+<!-- Hero Section -->
+<section class="max-w-max-width mx-auto px-margin-desktop mb-24 text-center">
+<h1 class="font-headline-xl text-headline-xl mb-6 tracking-tight">How can we help you?</h1>
+<p class="font-body-lg text-body-lg text-on-surface-variant max-w-2xl mx-auto mb-12">
+                Find answers to common questions about our custom digital solutions, pricing models, and development process.
+            </p>
+<!-- Search Bar -->
+<div class="max-w-xl mx-auto relative group">
+<div class="absolute inset-y-0 left-5 flex items-center pointer-events-none text-outline">
+<span class="material-symbols-outlined">search</span>
+</div>
+<input class="w-full pl-14 pr-6 py-5 bg-surface-container-lowest border-none rounded-2xl shadow-xl shadow-primary/5 focus:ring-2 focus:ring-electric-blue transition-all duration-300 font-body-md text-body-md text-on-surface placeholder:text-outline-variant" placeholder="Search for questions..." type="text">
+</div>
+</section>
+<!-- FAQ Content -->
+<section class="max-w-max-width mx-auto px-margin-desktop grid grid-cols-1 lg:grid-cols-12 gap-gutter items-start">
+<!-- Category Sidebar -->
+<aside class="lg:col-span-3 space-y-2 sticky top-28">
+<h3 class="font-label-sm text-label-sm text-outline uppercase tracking-widest mb-6 px-4">Categories</h3>
+<button class="category-btn w-full text-left px-4 py-3 rounded-xl font-body-md text-body-md text-electric-blue bg-primary-container/10 transition-all" onclick="switchCategory('all')">All Questions</button>
+<button class="category-btn w-full text-left px-4 py-3 rounded-xl font-body-md text-body-md text-on-surface-variant hover:bg-surface-container transition-all" onclick="switchCategory('services')">Services</button>
+<button class="category-btn w-full text-left px-4 py-3 rounded-xl font-body-md text-body-md text-on-surface-variant hover:bg-surface-container transition-all" onclick="switchCategory('pricing')">Pricing</button>
+<button class="category-btn w-full text-left px-4 py-3 rounded-xl font-body-md text-body-md text-on-surface-variant hover:bg-surface-container transition-all" onclick="switchCategory('process')">Process</button>
+</aside>
+<!-- Accordion List -->
+<div class="lg:col-span-9 space-y-4">
+<!-- Pricing Category -->
+<div class="faq-group" data-category="pricing">
+<h2 class="font-headline-md text-headline-md mb-6 text-on-surface">Pricing &amp; Plans</h2>
+<div class="space-y-4">
+<div class="faq-accordion-item bg-surface-container-lowest border border-outline-variant/30 rounded-2xl overflow-hidden shadow-sm transition-all hover:border-electric-blue/30">
+<button class="w-full flex items-center justify-between p-6 text-left focus:outline-none" onclick="toggleAccordion(this)">
+<span class="font-headline-md text-lg md:text-xl text-on-surface">Do you offer fixed-price projects?</span>
+<span class="material-symbols-outlined faq-chevron transition-transform duration-300 text-outline">expand_more</span>
+</button>
+<div class="faq-accordion-content px-6">
+<p class="text-on-surface-variant leading-relaxed">
+                                    Yes, for clearly defined scopes we provide fixed-price quotes. This is ideal for MVP development and specific feature enhancements where the requirements are well-documented from the start.
+                                </p>
+</div>
+</div>
+<div class="faq-accordion-item bg-surface-container-lowest border border-outline-variant/30 rounded-2xl overflow-hidden shadow-sm transition-all hover:border-electric-blue/30">
+<button class="w-full flex items-center justify-between p-6 text-left focus:outline-none" onclick="toggleAccordion(this)">
+<span class="font-headline-md text-lg md:text-xl text-on-surface">What are your hourly rates for ongoing support?</span>
+<span class="material-symbols-outlined faq-chevron transition-transform duration-300 text-outline">expand_more</span>
+</button>
+<div class="faq-accordion-content px-6">
+<p class="text-on-surface-variant leading-relaxed">
+                                    Our support and maintenance rates are tiered based on the complexity of the stack. We offer flexible retainer packages starting at 20 hours per month for priority support.
+                                </p>
+</div>
+</div>
+</div>
+</div>
+<!-- Services Category -->
+<div class="faq-group pt-8" data-category="services">
+<h2 class="font-headline-md text-headline-md mb-6 text-on-surface">Services</h2>
+<div class="space-y-4">
+<div class="faq-accordion-item bg-surface-container-lowest border border-outline-variant/30 rounded-2xl overflow-hidden shadow-sm transition-all hover:border-electric-blue/30">
+<button class="w-full flex items-center justify-between p-6 text-left focus:outline-none" onclick="toggleAccordion(this)">
+<span class="font-headline-md text-lg md:text-xl text-on-surface">Can you build custom mobile applications?</span>
+<span class="material-symbols-outlined faq-chevron transition-transform duration-300 text-outline">expand_more</span>
+</button>
+<div class="faq-accordion-content px-6">
+<p class="text-on-surface-variant leading-relaxed">
+                                    Absolutely. We specialize in cross-platform mobile development using Flutter and React Native, as well as native iOS and Android development for performance-critical applications.
+                                </p>
+</div>
+</div>
+<div class="faq-accordion-item bg-surface-container-lowest border border-outline-variant/30 rounded-2xl overflow-hidden shadow-sm transition-all hover:border-electric-blue/30">
+<button class="w-full flex items-center justify-between p-6 text-left focus:outline-none" onclick="toggleAccordion(this)">
+<span class="font-headline-md text-lg md:text-xl text-on-surface">Do you handle UI/UX design in-house?</span>
+<span class="material-symbols-outlined faq-chevron transition-transform duration-300 text-outline">expand_more</span>
+</button>
+<div class="faq-accordion-content px-6">
+<p class="text-on-surface-variant leading-relaxed">
+                                    Yes, our design team is integrated directly into our development lifecycle. We believe that great engineering starts with impeccable user experience and visual design.
+                                </p>
+</div>
+</div>
+</div>
+</div>
+<!-- Process Category -->
+<div class="faq-group pt-8" data-category="process">
+<h2 class="font-headline-md text-headline-md mb-6 text-on-surface">Our Process</h2>
+<div class="space-y-4">
+<div class="faq-accordion-item bg-surface-container-lowest border border-outline-variant/30 rounded-2xl overflow-hidden shadow-sm transition-all hover:border-electric-blue/30">
+<button class="w-full flex items-center justify-between p-6 text-left focus:outline-none" onclick="toggleAccordion(this)">
+<span class="font-headline-md text-lg md:text-xl text-on-surface">How long does a typical project take?</span>
+<span class="material-symbols-outlined faq-chevron transition-transform duration-300 text-outline">expand_more</span>
+</button>
+<div class="faq-accordion-content px-6">
+<p class="text-on-surface-variant leading-relaxed">
+                                    MVPs typically take 8-12 weeks from discovery to launch. Enterprise-scale transformations can span 6 months or longer, managed through agile two-week sprints.
+                                </p>
+</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+<!-- Still Have Questions? Section -->
+<section class="max-w-max-width mx-auto px-margin-desktop mt-32">
+<div class="relative rounded-3xl overflow-hidden bg-primary p-12 md:p-20 text-center">
+<!-- Background decoration -->
+<div class="absolute top-0 right-0 w-64 h-64 bg-white/10 rounded-full blur-3xl -mr-32 -mt-32"></div>
+<div class="absolute bottom-0 left-0 w-48 h-48 bg-white/5 rounded-full blur-2xl -ml-24 -mb-24"></div>
+<div class="relative z-10 max-w-2xl mx-auto">
+<h2 class="font-headline-lg text-headline-lg text-on-primary mb-6">Still have questions?</h2>
+<p class="font-body-lg text-body-lg text-on-primary-container mb-10 opacity-90">
+                        Can't find the answer you're looking for? Our dedicated support team is here to help you navigate your digital journey.
+                    </p>
+<div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+<a class="bg-on-primary text-primary px-8 py-4 rounded-full font-label-md text-label-md hover:scale-105 transition-transform duration-200" href="#">
+                            Contact Support
+                        </a>
+<a class="border border-on-primary text-on-primary px-8 py-4 rounded-full font-label-md text-label-md hover:bg-white/10 transition-colors duration-200" href="contact.html">
+                            Book a Consultation
+                        </a>
+</div>
+</div>
+</div>
+</section>
+</main>
+<!-- Footer -->
+<footer class="w-full bg-surface-container-lowest border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-16 grid grid-cols-2 md:grid-cols-4 gap-8">
+<div class="col-span-2 md:col-span-1">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary" style="cursor:pointer">InviteYou.ca</a>
+<p class="font-body-md text-body-md text-on-surface-variant mt-4 max-w-xs">Architecting custom business solutions with high-tech innovation and institutional reliability.</p>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Company</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="about.html">About</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="careers.html">Careers</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Contact</a></li>
+</ul>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Expertise</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="services.html">Services</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="solutions.html">Solutions</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="process.html">Process</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="portfolio.html">Portfolio</a></li>
+</ul>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Support</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="faq.html">FAQ</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Contact</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Get Started</a></li>
+</ul>
+</div>
+</div>
+<div class="border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-6 flex flex-col md:flex-row justify-between items-center gap-4">
+<p class="font-label-sm text-label-sm text-on-surface-variant">© 2024 InviteYou.ca Business Solutions. All rights reserved.</p>
+<div class="flex flex-wrap justify-center gap-6">
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Privacy Policy</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Terms of Service</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Cookie Policy</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Sitemap</a>
+</div>
+</div>
+</div>
+</footer>
+<script>
+        function toggleAccordion(button) {
+            const item = button.parentElement;
+            const isActive = item.classList.contains('active');
+            
+            // Close all items
+            document.querySelectorAll('.faq-accordion-item').forEach(el => {
+                el.classList.remove('active');
+            });
+            
+            // Open clicked item if it wasn't active
+            if (!isActive) {
+                item.classList.add('active');
+            }
+        }
+
+        function switchCategory(category) {
+            // Update active state of buttons
+            const buttons = document.querySelectorAll('.category-btn');
+            buttons.forEach(btn => {
+                btn.classList.remove('text-electric-blue', 'bg-primary-container/10');
+                btn.classList.add('text-on-surface-variant');
+                if (btn.innerText.toLowerCase().includes(category)) {
+                    btn.classList.add('text-electric-blue', 'bg-primary-container/10');
+                    btn.classList.remove('text-on-surface-variant');
+                } else if (category === 'all' && btn.innerText.includes('All')) {
+                    btn.classList.add('text-electric-blue', 'bg-primary-container/10');
+                    btn.classList.remove('text-on-surface-variant');
+                }
+            });
+
+            // Show/Hide groups
+            const groups = document.querySelectorAll('.faq-group');
+            groups.forEach(group => {
+                if (category === 'all') {
+                    group.classList.remove('hidden');
+                } else if (group.dataset.category === category) {
+                    group.classList.remove('hidden');
+                } else {
+                    group.classList.add('hidden');
+                }
+            });
+        }
+    </script>
+</body></html>

--- a/marketing/index.html
+++ b/marketing/index.html
@@ -1,0 +1,584 @@
+<!DOCTYPE html><html class="scroll-smooth" lang="en" style=""><head>
+<meta charset="utf-8">
+<meta content="width=device-width, initial-scale=1.0" name="viewport">
+<title>InviteYou.ca - Custom Business Solutions</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com" rel="preconnect">
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect">
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@500&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet">
+<script id="tailwind-config">
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    "colors": {
+                        "on-tertiary-fixed-variant": "#7f292c",
+                        "inverse-primary": "#b4c5ff",
+                        "surface-container-highest": "#e0e3e8",
+                        "surface-container-high": "#e5e8ee",
+                        "surface-container": "#ebeef3",
+                        "secondary-container": "#67fcc6",
+                        "background": "#f7f9ff",
+                        "outline": "#737687",
+                        "soft-teal": "#20C997",
+                        "surface-subtle": "#FBF2F2",
+                        "on-primary-fixed-variant": "#003ea8",
+                        "secondary": "#006c4f",
+                        "on-error": "#ffffff",
+                        "on-error-container": "#93000a",
+                        "on-primary": "#ffffff",
+                        "on-secondary-container": "#007354",
+                        "ghost-white": "#F8F9FA",
+                        "surface-variant": "#e0e3e8",
+                        "inverse-on-surface": "#eef1f6",
+                        "on-secondary-fixed": "#002116",
+                        "on-secondary-fixed-variant": "#00513a",
+                        "tertiary": "#94393b",
+                        "secondary-fixed-dim": "#44dfab",
+                        "on-surface": "#181c20",
+                        "surface-tint": "#0053da",
+                        "error-container": "#ffdad6",
+                        "tertiary-fixed-dim": "#ffb3b1",
+                        "on-secondary": "#ffffff",
+                        "inverse-surface": "#2d3135",
+                        "on-tertiary-fixed": "#410007",
+                        "outline-variant": "#c2c6d9",
+                        "tertiary-fixed": "#ffdad8",
+                        "surface-container-low": "#f1f4f9",
+                        "on-surface-variant": "#424656",
+                        "on-tertiary": "#ffffff",
+                        "on-tertiary-container": "#fff1ef",
+                        "on-primary-container": "#f3f3ff",
+                        "on-background": "#181c20",
+                        "surface": "#f7f9ff",
+                        "primary": "#004cca",
+                        "primary-container": "#0062ff",
+                        "secondary-fixed": "#67fcc6",
+                        "surface-dim": "#d7dadf",
+                        "surface-container-lowest": "#ffffff",
+                        "surface-bright": "#f7f9ff",
+                        "tertiary-container": "#b35052",
+                        "primary-fixed-dim": "#b4c5ff",
+                        "electric-blue": "#0062FF",
+                        "primary-fixed": "#dbe1ff",
+                        "error": "#ba1a1a",
+                        "on-primary-fixed": "#00174b"
+                    },
+                    "borderRadius": {
+                        "DEFAULT": "0.25rem",
+                        "lg": "0.5rem",
+                        "xl": "0.75rem",
+                        "full": "9999px"
+                    },
+                    "spacing": {
+                        "max-width": "1280px",
+                        "gutter": "24px",
+                        "margin-mobile": "16px",
+                        "margin-desktop": "64px",
+                        "unit": "4px"
+                    },
+                    "fontFamily": {
+                        "body-md": ["Inter"],
+                        "label-md": ["JetBrains Mono"],
+                        "headline-lg": ["Hanken Grotesk"],
+                        "headline-xl": ["Hanken Grotesk"],
+                        "headline-lg-mobile": ["Hanken Grotesk"],
+                        "headline-md": ["Hanken Grotesk"],
+                        "body-lg": ["Inter"],
+                        "label-sm": ["JetBrains Mono"]
+                    },
+                    "fontSize": {
+                        "body-md": ["16px", { "lineHeight": "24px", "fontWeight": "400" }],
+                        "label-md": ["14px", { "lineHeight": "20px", "letterSpacing": "0.05em", "fontWeight": "500" }],
+                        "headline-lg": ["48px", { "lineHeight": "56px", "letterSpacing": "-0.01em", "fontWeight": "600" }],
+                        "headline-xl": ["64px", { "lineHeight": "72px", "letterSpacing": "-0.02em", "fontWeight": "700" }],
+                        "headline-lg-mobile": ["32px", { "lineHeight": "40px", "fontWeight": "600" }],
+                        "headline-md": ["32px", { "lineHeight": "40px", "fontWeight": "600" }],
+                        "body-lg": ["18px", { "lineHeight": "28px", "fontWeight": "400" }],
+                        "label-sm": ["12px", { "lineHeight": "16px", "letterSpacing": "0.05em", "fontWeight": "500" }]
+                    },
+                    "boxShadow": {
+                        'ambient': '0 40px 80px -20px rgba(0, 0, 0, 0.04)',
+                        'hover': '0 50px 100px -20px rgba(0, 0, 0, 0.08)',
+                    }
+                }
+            }
+        }
+    </script>
+<style>
+        .reveal {
+            opacity: 0;
+            transform: translateY(30px);
+            transition: all 0.8s cubic-bezier(0.16, 1, 0.3, 1);
+        }
+        
+        .reveal.active {
+            opacity: 1;
+            transform: translateY(0);
+        }
+        
+        .hero-text {
+            opacity: 0;
+            transform: scale(0.95);
+            transition: all 1.2s cubic-bezier(0.16, 1, 0.3, 1);
+        }
+        
+        .hero-text.active {
+            opacity: 1;
+            transform: scale(1);
+        }
+
+        .timeline-marker {
+            transition: background-color 0.4s ease, transform 0.4s ease;
+        }
+        
+        .timeline-marker.active {
+            background-color: #0062FF; /* electric-blue */
+            transform: scale(1.2);
+            box-shadow: 0 0 15px rgba(0, 98, 255, 0.4);
+        }
+        
+        .timeline-line {
+            transition: height 1.5s cubic-bezier(0.16, 1, 0.3, 1);
+        }
+
+        .glass-nav {
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+        }
+        
+        .card-tilt {
+            transition: transform 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94), box-shadow 0.3s ease;
+        }
+        
+        .card-tilt:hover {
+            transform: translateY(-8px) perspective(1000px) rotateX(2deg) rotateY(-2deg);
+            box-shadow: 0 30px 60px -15px rgba(0, 0, 0, 0.1);
+        }
+        
+        /* Material Icon Font styling setup */
+        .material-symbols-outlined {
+          font-variation-settings:
+          'FILL' 0,
+          'wght' 400,
+          'GRAD' 0,
+          'opsz' 24
+        }
+    </style>
+</head>
+<body class="bg-background text-on-surface font-body-md antialiased overflow-x-hidden selection:bg-primary-container selection:text-on-primary-container">
+<!-- Top Navigation from Shared Components -->
+<header class="fixed top-0 left-0 w-full z-50 bg-surface/70 backdrop-blur-xl shadow-sm">
+<div class="flex justify-between items-center max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-4">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary tracking-tight" style="cursor:pointer">InviteYou.ca</a>
+<nav class="hidden md:flex items-center space-x-8">
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="services.html">Services</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="solutions.html">Solutions</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="process.html">Process</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="portfolio.html">Portfolio</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="about.html">About</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="contact.html">Contact</a>
+</nav>
+<a href="contact.html"><button class="bg-primary-container text-on-primary-container px-6 py-2.5 rounded-full font-label-md text-label-md hover:scale-105 hover:shadow-md transition-all duration-200 active:scale-95">Get Started</button></a>
+</div>
+</header>
+<!-- Mobile Header (simplified fallback for structural compliance) -->
+
+<!-- Main Content Canvas -->
+<main class="w-full">
+<!-- Hero Section -->
+<section class="relative h-screen w-full flex items-center justify-center overflow-hidden">
+<!-- Shader Background -->
+<div class="absolute inset-0 z-0 w-full h-full">
+<!-- STITCH_SHADER_START:ANIMATION_2 class="absolute inset-0 w-full h-full opacity-60" -->
+<div class="absolute inset-0 w-full h-full opacity-60" style="display:block;">
+<canvas id="shader-canvas-ANIMATION_2" style="display:block;width:100%;height:100%" width="1280" height="3402"></canvas>
+<script>
+(function() {
+  const canvas = document.getElementById('shader-canvas-ANIMATION_2');
+
+  // Sync the WebGL drawing-buffer size with the CSS-driven layout size.
+  // This fires on initial layout and whenever the element is resized.
+  function syncSize() {
+    const w = canvas.clientWidth  || 1280;
+    const h = canvas.clientHeight || 720;
+    if (canvas.width !== w || canvas.height !== h) {
+      canvas.width  = w;
+      canvas.height = h;
+    }
+  }
+  if (typeof ResizeObserver !== 'undefined') {
+    new ResizeObserver(syncSize).observe(canvas);
+  }
+  syncSize();
+
+  const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+  if (!gl) return;
+  const vs = `attribute vec2 a_position;
+varying vec2 v_texCoord;
+void main() {
+  v_texCoord = a_position * 0.5 + 0.5;
+  gl_Position = vec4(a_position, 0.0, 1.0);
+}`;
+  const fs = `precision highp float;
+uniform float u_time;
+uniform vec2 u_resolution;
+uniform vec2 u_mouse;
+varying vec2 v_texCoord;
+
+void main() {
+    vec2 uv = v_texCoord;
+    vec2 mouse = u_mouse / u_resolution;
+    
+    // Create a flowing, bright gradient background
+    float color1 = sin(uv.x * 10.0 + u_time * 0.5) * 0.5 + 0.5;
+    float color2 = cos(uv.y * 8.0 - u_time * 0.3) * 0.5 + 0.5;
+    
+    vec3 colorA = vec3(0.97, 0.98, 1.0); // surface-bright (approx)
+    vec3 colorB = vec3(0.0, 0.38, 1.0);  // custom primary blue
+    
+    vec3 finalColor = mix(colorA, colorB, (color1 * color2) * 0.1);
+    
+    // Subtle mouse interaction
+    float dist = distance(uv, mouse);
+    finalColor += (1.0 - smoothstep(0.0, 0.3, dist)) * 0.05;
+
+    gl_FragColor = vec4(finalColor, 1.0);
+}`;
+  function cs(type, src) {
+    const s = gl.createShader(type);
+    gl.shaderSource(s, src);
+    gl.compileShader(s);
+    return s;
+  }
+  const prog = gl.createProgram();
+  gl.attachShader(prog, cs(gl.VERTEX_SHADER, vs));
+  gl.attachShader(prog, cs(gl.FRAGMENT_SHADER, fs));
+  gl.linkProgram(prog);
+  gl.useProgram(prog);
+  const buf = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+  gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, 1,1]), gl.STATIC_DRAW);
+  const pos = gl.getAttribLocation(prog, 'a_position');
+  gl.enableVertexAttribArray(pos);
+  gl.vertexAttribPointer(pos, 2, gl.FLOAT, false, 0, 0);
+  const uTime = gl.getUniformLocation(prog, 'u_time');
+  const uRes = gl.getUniformLocation(prog, 'u_resolution');
+  const uMouse = gl.getUniformLocation(prog, 'u_mouse');
+
+  // u_mouse is in pixel coordinates matching u_resolution (ShaderToy convention).
+  // Shaders that need normalized coords should use: u_mouse / u_resolution.
+  let mouse = { x: canvas.width / 2, y: canvas.height / 2 };
+  window.addEventListener('mousemove', (event) => {
+    const rect = canvas.getBoundingClientRect();
+    if (rect.width && rect.height) {
+      const nx = (event.clientX - rect.left) / rect.width;
+      const ny = 1.0 - (event.clientY - rect.top) / rect.height;
+      mouse.x = nx * canvas.width;
+      mouse.y = ny * canvas.height;
+    }
+  });
+
+  function render(t) {
+    if (typeof ResizeObserver === 'undefined') syncSize();
+    gl.viewport(0, 0, canvas.width, canvas.height);
+    if (uTime) gl.uniform1f(uTime, t * 0.001);
+    if (uRes) gl.uniform2f(uRes, canvas.width, canvas.height);
+    if (uMouse) gl.uniform2f(uMouse, mouse.x, mouse.y);
+    gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+    requestAnimationFrame(render);
+  }
+  render(0);
+})();
+</script>
+</div>
+<!-- STITCH_SHADER_END:ANIMATION_2 -->
+</div>
+<!-- Hero Content -->
+<div class="relative z-10 max-w-max-width mx-auto px-gutter text-center flex flex-col items-center">
+<div class="hero-text active inline-flex flex-col items-center">
+<span class="font-label-md text-label-md text-electric-blue uppercase tracking-widest mb-6 px-4 py-1.5 bg-electric-blue/10 rounded-full inline-block backdrop-blur-sm border border-electric-blue/20">Enterprise Grade Innovation</span>
+<h1 class="font-headline-xl text-headline-xl md:text-[80px] md:leading-[88px] font-bold text-on-surface mb-6 max-w-4xl tracking-tight">
+                        Architecting Custom <br><span class="text-transparent bg-clip-text bg-gradient-to-r from-electric-blue to-soft-teal">Business Solutions</span>
+</h1>
+<p class="font-body-lg text-body-lg text-on-surface-variant max-w-2xl mb-10 mx-auto">
+                        We blend high-tech innovation with institutional reliability to build digital platforms that drive operational excellence and scalable growth.
+                    </p>
+<div class="flex flex-col sm:flex-row gap-4 justify-center">
+<a class="px-8 py-4 bg-electric-blue text-on-primary font-label-md text-label-md rounded uppercase tracking-widest hover:scale-102 hover:shadow-hover transition-all duration-200" href="services.html">
+                            Explore Capabilities
+                        </a>
+<a class="px-8 py-4 bg-transparent border-2 border-electric-blue text-electric-blue font-label-md text-label-md rounded uppercase tracking-widest hover:bg-electric-blue/5 hover:scale-102 transition-all duration-200" href="#contact">
+                            Book Consultation
+                        </a>
+</div>
+</div>
+</div>
+<!-- Scroll Indicator -->
+<div class="absolute bottom-10 left-1/2 transform -translate-x-1/2 flex flex-col items-center animate-bounce opacity-50">
+<span class="font-label-sm text-label-sm text-on-surface-variant mb-2 uppercase">Scroll</span>
+<span class="material-symbols-outlined text-on-surface-variant">arrow_downward</span>
+</div>
+</section>
+<!-- Why InviteYou (value props; no numeric claims) -->
+<section class="py-[128px] w-full bg-white relative" id="why-us">
+<div class="max-w-max-width mx-auto px-gutter">
+<div class="mb-[64px] reveal flex flex-col md:flex-row md:justify-between md:items-end gap-6">
+<div class="max-w-2xl">
+<span class="font-label-md text-label-md text-electric-blue uppercase tracking-widest mb-4 block">Why InviteYou</span>
+<h2 class="font-headline-lg text-headline-lg md:text-headline-lg font-bold text-on-surface mb-4">Built for Trust, Engineered for Scale</h2>
+<p class="font-body-lg text-body-lg text-on-surface-variant max-w-2xl">We pair high-tech innovation with institutional reliability, so every engagement is transparent, secure, and built to last.</p>
+</div>
+<a class="hidden md:flex font-label-md text-label-md text-electric-blue items-center uppercase hover:opacity-80 transition-opacity whitespace-nowrap" href="services.html">Explore Our Services <span class="material-symbols-outlined ml-2">arrow_forward</span></a>
+</div>
+<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
+<div class="reveal border-t-2 border-electric-blue pt-6" style="transition-delay: 100ms;">
+<span class="material-symbols-outlined text-electric-blue text-3xl mb-4" style="font-variation-settings: 'FILL' 1;">shield</span>
+<h3 class="font-headline-md text-[22px] leading-[28px] font-semibold text-on-surface mb-2">Enterprise-Grade Security</h3>
+<p class="font-body-md text-body-md text-on-surface-variant">Security and compliance are built into every layer of architecture from day one.</p>
+</div>
+<div class="reveal border-t-2 border-electric-blue pt-6" style="transition-delay: 200ms;">
+<span class="material-symbols-outlined text-electric-blue text-3xl mb-4" style="font-variation-settings: 'FILL' 1;">visibility</span>
+<h3 class="font-headline-md text-[22px] leading-[28px] font-semibold text-on-surface mb-2">Transparent Process</h3>
+<p class="font-body-md text-body-md text-on-surface-variant">A rigorous, open methodology with regular reviews and no surprises at delivery.</p>
+</div>
+<div class="reveal border-t-2 border-electric-blue pt-6" style="transition-delay: 300ms;">
+<span class="material-symbols-outlined text-electric-blue text-3xl mb-4" style="font-variation-settings: 'FILL' 1;">groups</span>
+<h3 class="font-headline-md text-[22px] leading-[28px] font-semibold text-on-surface mb-2">Dedicated Senior Teams</h3>
+<p class="font-body-md text-body-md text-on-surface-variant">You work directly with experienced engineers and strategists, not layers of handoffs.</p>
+</div>
+<div class="reveal border-t-2 border-electric-blue pt-6" style="transition-delay: 400ms;">
+<span class="material-symbols-outlined text-electric-blue text-3xl mb-4" style="font-variation-settings: 'FILL' 1;">rocket_launch</span>
+<h3 class="font-headline-md text-[22px] leading-[28px] font-semibold text-on-surface mb-2">Scalable by Design</h3>
+<p class="font-body-md text-body-md text-on-surface-variant">Solutions architected to grow with your business, avoiding costly rebuilds later.</p>
+</div>
+</div>
+<div class="mt-12 text-center md:hidden reveal">
+<a class="inline-flex font-label-md text-label-md text-electric-blue items-center uppercase px-6 py-3 border border-electric-blue rounded" href="services.html">Explore Our Services <span class="material-symbols-outlined ml-2">arrow_forward</span></a>
+</div>
+</div>
+</section>
+<!-- Process Section (Vertical Timeline) -->
+<section class="py-[128px] w-full bg-surface-container-low border-y border-outline-variant/20" id="process">
+<div class="max-w-max-width mx-auto px-gutter">
+<div class="text-center mb-[96px] reveal active">
+<h2 class="font-headline-lg text-headline-lg md:text-headline-lg font-bold text-on-surface mb-4">The Engagement Process</h2>
+<p class="font-body-lg text-body-lg text-on-surface-variant max-w-2xl mx-auto">A rigorous, transparent methodology ensuring predictable outcomes.</p>
+</div>
+<div class="relative max-w-4xl mx-auto">
+<!-- Central Line -->
+<div class="absolute left-4 md:left-1/2 top-0 bottom-0 w-[2px] bg-outline-variant/30 transform md:-translate-x-1/2">
+<div class="absolute top-0 left-0 w-full bg-electric-blue h-0 timeline-line" id="timeline-progress" style="height: calc(100% + 0px);"></div>
+</div>
+<!-- Timeline Items -->
+<div class="space-y-24 relative">
+<!-- Phase 1 -->
+<div class="reveal flex flex-col md:flex-row items-center w-full timeline-row group active" data-phase="1">
+<div class="md:w-1/2 w-full pl-16 md:pl-0 md:pr-16 md:text-right">
+<span class="font-label-md text-label-md text-electric-blue uppercase tracking-widest mb-2 block">Phase 01</span>
+<h3 class="font-headline-md text-headline-md text-on-surface mb-4">Discovery &amp; Audit</h3>
+<p class="font-body-md text-body-md text-on-surface-variant">Deep-dive analysis of existing infrastructure, stakeholder interviews, and definition of technical requirements.</p>
+</div>
+<!-- Marker -->
+<div class="absolute left-4 md:left-1/2 transform -translate-x-1/2 w-8 h-8 rounded-full border-4 border-surface-container-low bg-outline-variant timeline-marker z-10 active"></div>
+<div class="md:w-1/2 w-full hidden md:block"></div>
+</div>
+<!-- Phase 2 -->
+<div class="reveal flex flex-col md:flex-row items-center w-full timeline-row group active" data-phase="2">
+<div class="md:w-1/2 w-full hidden md:block"></div>
+<!-- Marker -->
+<div class="absolute left-4 md:left-1/2 transform -translate-x-1/2 w-8 h-8 rounded-full border-4 border-surface-container-low bg-outline-variant timeline-marker z-10 active"></div>
+<div class="md:w-1/2 w-full pl-16 md:pl-16">
+<span class="font-label-md text-label-md text-electric-blue uppercase tracking-widest mb-2 block">Phase 02</span>
+<h3 class="font-headline-md text-headline-md text-on-surface mb-4">Architecture Design</h3>
+<p class="font-body-md text-body-md text-on-surface-variant">Structuring data models, system integrations, and crafting wireframes that prioritize user flows and security.</p>
+</div>
+</div>
+<!-- Phase 3 -->
+<div class="reveal flex flex-col md:flex-row items-center w-full timeline-row group active" data-phase="3">
+<div class="md:w-1/2 w-full pl-16 md:pl-0 md:pr-16 md:text-right">
+<span class="font-label-md text-label-md text-electric-blue uppercase tracking-widest mb-2 block">Phase 03</span>
+<h3 class="font-headline-md text-headline-md text-on-surface mb-4">Agile Implementation</h3>
+<p class="font-body-md text-body-md text-on-surface-variant">Iterative development sprints with continuous integration, automated testing, and regular stakeholder reviews.</p>
+</div>
+<!-- Marker -->
+<div class="absolute left-4 md:left-1/2 transform -translate-x-1/2 w-8 h-8 rounded-full border-4 border-surface-container-low bg-outline-variant timeline-marker z-10 active"></div>
+<div class="md:w-1/2 w-full hidden md:block"></div>
+</div>
+</div>
+</div>
+</div>
+</section>
+<!-- Portfolio Section (Asymmetric / Parallax Cards) -->
+<section class="py-[128px] w-full bg-white" id="portfolio">
+<div class="max-w-max-width mx-auto px-gutter">
+<div class="flex flex-col md:flex-row justify-between items-end mb-[64px] reveal active">
+<div class="max-w-xl">
+<h2 class="font-headline-lg text-headline-lg md:text-headline-lg font-bold text-on-surface mb-4">Featured Engagements</h2>
+<p class="font-body-lg text-body-lg text-on-surface-variant">Transformative digital solutions delivered for enterprise partners.</p>
+</div>
+<a class="hidden md:flex font-label-md text-label-md text-electric-blue items-center uppercase hover:opacity-80 transition-opacity" href="portfolio.html">View Portfolio <span class="material-symbols-outlined ml-2">arrow_forward</span></a>
+</div>
+<div class="grid grid-cols-1 md:grid-cols-12 gap-8 items-center">
+<!-- Portfolio Item 1 (Large) -->
+<div class="md:col-span-8 reveal relative group cursor-pointer card-tilt active">
+<div class="aspect-[16/9] w-full rounded-xl overflow-hidden shadow-ambient bg-surface-variant relative">
+<!-- Image overlay -->
+<div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent z-10 opacity-60 group-hover:opacity-80 transition-opacity duration-300"></div>
+<div class="bg-cover bg-center w-full h-full absolute inset-0 transform group-hover:scale-105 transition-transform duration-700 ease-out" data-alt="A sleek, modern dashboard interface displayed on a high-resolution laptop screen, set in a brightly lit, minimalist corporate office environment. The UI features stark white backgrounds, precise geometric data visualizations in electric blue and soft teal, and crisp typography. The atmosphere is professional, cutting-edge, and highly organized." style="background-image: url('https://lh3.googleusercontent.com/aida-public/AB6AXuAd-rgcA9cdb04AIM903HBFb2WpfMUdq6_Jnb1PFPExs3qKk33hq9rruZxFBy7YKTDy-H3UtlVBfzQPZAU91R8LX9EjLB7uku735KVc5h2ywDj_k7ybaOQ-JS4DlONtRIl1SQtDsoU8Um3reuzjP0EQ1ydAwWQheOquwE_B4sTAJtElOjbZoQHy5BQLE2FfQhN3ueZSWfBTgJFmPk8FU5aDBK5nud_aaKZghfFpXSNSX_Tm5q9vLEFVb8LdXpkKpyqSsV53V1CmjG0')"></div>
+<!-- Content overlay -->
+<div class="absolute bottom-0 left-0 w-full p-8 z-20 transform translate-y-4 group-hover:translate-y-0 transition-transform duration-300">
+<div class="flex gap-2 mb-3">
+<span class="font-label-sm text-label-sm px-3 py-1 bg-white/20 backdrop-blur-md text-white rounded uppercase tracking-wider">FinTech</span>
+<span class="font-label-sm text-label-sm px-3 py-1 bg-white/20 backdrop-blur-md text-white rounded uppercase tracking-wider">Dashboard</span>
+</div>
+<h3 class="font-headline-md text-headline-md text-white mb-2">Nexus Analytics Platform</h3>
+<p class="font-body-md text-body-md text-white/80 max-w-xl opacity-0 group-hover:opacity-100 transition-opacity duration-300 delay-100">A comprehensive data visualization suite streamlining global transaction monitoring.</p>
+</div>
+</div>
+</div>
+<!-- Portfolio Item 2 (Small) -->
+<div class="md:col-span-4 reveal relative group cursor-pointer card-tilt active" style="transition-delay: 200ms;">
+<div class="aspect-[4/5] w-full rounded-xl overflow-hidden shadow-ambient bg-surface-variant relative">
+<div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent z-10 opacity-60 group-hover:opacity-80 transition-opacity duration-300"></div>
+<div class="bg-cover bg-center w-full h-full absolute inset-0 transform group-hover:scale-105 transition-transform duration-700 ease-out" data-alt="A minimalist mobile application interface displayed on a smartphone held by a professional hand. The screen shows a clean, white-themed logistics tracking screen with subtle shadow depth and vibrant electric blue status indicators. The background is softly blurred out, emphasizing the crisp, modern UI design of the app." style="background-image: url('https://lh3.googleusercontent.com/aida-public/AB6AXuAcxEpXyBjOP3geQpvCwyHbRBejtiy-V-DrkRXAuTq0CCpL-VDF3_yfFsxd4raCM5Hl-LhsYUGm6JFIa5pY6DrXp_7TyFmVY6AmbQWQP4nbhdpkKU-Ll9_DhZRSIGBPObEoLXgA82WDT8fmIJeINvdoeEq2r-4J4zBl1WqHoZ4DNNBQxmpcCNqqEy16wHRvj6v03tZyRirNQa1kzDsqTOauQeUAi7d42DMIdlRsBdq9fqw2Vxjobni8cjs46JGft_vWNbGAlVdapNw')"></div>
+<div class="absolute bottom-0 left-0 w-full p-6 z-20">
+<span class="font-label-sm text-label-sm px-3 py-1 bg-white/20 backdrop-blur-md text-white rounded uppercase tracking-wider mb-3 inline-block">Logistics</span>
+<h3 class="font-headline-md text-[24px] leading-[32px] font-semibold text-white">RouteSync Mobile</h3>
+</div>
+</div>
+</div>
+</div>
+<div class="mt-8 text-center md:hidden reveal">
+<a class="inline-flex font-label-md text-label-md text-electric-blue items-center uppercase px-6 py-3 border border-electric-blue rounded" href="portfolio.html">View Portfolio</a>
+</div>
+</div>
+</section>
+</main>
+<!-- Footer from Shared Components JSON -->
+<footer class="w-full bg-surface-container-lowest border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-16 grid grid-cols-2 md:grid-cols-4 gap-8">
+<div class="col-span-2 md:col-span-1">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary" style="cursor:pointer">InviteYou.ca</a>
+<p class="font-body-md text-body-md text-on-surface-variant mt-4 max-w-xs">Architecting custom business solutions with high-tech innovation and institutional reliability.</p>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Company</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="about.html">About</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="careers.html">Careers</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Contact</a></li>
+</ul>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Expertise</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="services.html">Services</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="solutions.html">Solutions</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="process.html">Process</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="portfolio.html">Portfolio</a></li>
+</ul>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Support</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="faq.html">FAQ</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Contact</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Get Started</a></li>
+</ul>
+</div>
+</div>
+<div class="border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-6 flex flex-col md:flex-row justify-between items-center gap-4">
+<p class="font-label-sm text-label-sm text-on-surface-variant">© 2024 InviteYou.ca Business Solutions. All rights reserved.</p>
+<div class="flex flex-wrap justify-center gap-6">
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Privacy Policy</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Terms of Service</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Cookie Policy</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Sitemap</a>
+</div>
+</div>
+</div>
+</footer>
+<!-- Interaction Scripts -->
+<script>
+        document.addEventListener('DOMContentLoaded', () => {
+            // Scroll Reveal Logic
+            const revealElements = document.querySelectorAll('.reveal');
+            
+            const revealObserver = new IntersectionObserver((entries) => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        entry.target.classList.add('active');
+                        // Optional: stop observing once revealed
+                        // revealObserver.unobserve(entry.target); 
+                    }
+                });
+            }, {
+                root: null,
+                threshold: 0.1,
+                rootMargin: "0px 0px -50px 0px"
+            });
+            
+            revealElements.forEach(el => revealObserver.observe(el));
+
+            // Hero Text specific reveal (delayed slightly after load)
+            setTimeout(() => {
+                const heroText = document.querySelector('.hero-text');
+                if(heroText) heroText.classList.add('active');
+            }, 300);
+
+            // Timeline Scroll Logic
+            const timelineRows = document.querySelectorAll('.timeline-row');
+            const timelineProgress = document.getElementById('timeline-progress');
+            const timelineSection = document.getElementById('process');
+            
+            if (timelineRows.length > 0 && timelineProgress && timelineSection) {
+                
+                const updateTimeline = () => {
+                    const sectionRect = timelineSection.getBoundingClientRect();
+                    const windowHeight = window.innerHeight;
+                    
+                    // Only process if section is in view
+                    if (sectionRect.top < windowHeight && sectionRect.bottom > 0) {
+                        
+                        let maxPhase = 0;
+                        
+                        timelineRows.forEach((row, index) => {
+                            const rect = row.getBoundingClientRect();
+                            const marker = row.querySelector('.timeline-marker');
+                            
+                            // If middle of the row is past the middle of the screen
+                            if (rect.top + (rect.height / 2) < windowHeight * 0.75) {
+                                marker.classList.add('active');
+                                maxPhase = index + 1;
+                            } else {
+                                marker.classList.remove('active');
+                            }
+                        });
+
+                        // Set line height based on active phases
+                        if (maxPhase > 0) {
+                            const totalPhases = timelineRows.length;
+                            const percentage = (maxPhase / totalPhases) * 100;
+                            // Add a little extra to connect to the active marker visually
+                            timelineProgress.style.height = `calc(${percentage}% - ${(totalPhases - maxPhase) * 10}px)`;
+                        } else {
+                            timelineProgress.style.height = '0%';
+                        }
+                    }
+                };
+
+                window.addEventListener('scroll', updateTimeline);
+                // Initial check
+                updateTimeline();
+            }
+        });
+    </script>
+
+
+
+
+</body></html>

--- a/marketing/nginx-inviteyou-marketing.conf
+++ b/marketing/nginx-inviteyou-marketing.conf
@@ -1,0 +1,48 @@
+# Static marketing site for inviteyou.ca + www.inviteyou.ca
+# Files are deployed to /var/www/inviteyou-web by .github/workflows/marketing.yml
+# NOTE: leave the existing we.inviteyou.ca and api.inviteyou.ca server blocks unchanged.
+
+# HTTP -> HTTPS redirect for apex + www
+server {
+    listen 80;
+    listen [::]:80;
+    server_name inviteyou.ca www.inviteyou.ca;
+    return 301 https://$host$request_uri;
+}
+
+# Redirect www -> apex over HTTPS (canonical host)
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name www.inviteyou.ca;
+
+    # Reuse the existing certbot-managed certificate (must cover apex + www).
+    ssl_certificate     /etc/letsencrypt/live/inviteyou.ca/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/inviteyou.ca/privkey.pem;
+
+    return 301 https://inviteyou.ca$request_uri;
+}
+
+# Serve the static marketing site on the apex domain
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name inviteyou.ca;
+
+    root /var/www/inviteyou-web;
+    index index.html;
+
+    ssl_certificate     /etc/letsencrypt/live/inviteyou.ca/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/inviteyou.ca/privkey.pem;
+
+    # Clean URLs: /about -> /about.html, plus normal file/dir handling.
+    location / {
+        try_files $uri $uri.html $uri/ =404;
+    }
+
+    # Long cache for static assets
+    location ~* \.(?:css|js|png|jpg|jpeg|gif|svg|ico|woff2?)$ {
+        expires 30d;
+        add_header Cache-Control "public";
+    }
+}

--- a/marketing/nginx-inviteyou-marketing.conf
+++ b/marketing/nginx-inviteyou-marketing.conf
@@ -1,48 +1,129 @@
-# Static marketing site for inviteyou.ca + www.inviteyou.ca
-# Files are deployed to /var/www/inviteyou-web by .github/workflows/marketing.yml
-# NOTE: leave the existing we.inviteyou.ca and api.inviteyou.ca server blocks unchanged.
-
-# HTTP -> HTTPS redirect for apex + www
+# Apex inviteyou.ca -> static marketing site (/var/www/inviteyou-web)
 server {
-    listen 80;
-    listen [::]:80;
-    server_name inviteyou.ca www.inviteyou.ca;
-    return 301 https://$host$request_uri;
-}
-
-# Redirect www -> apex over HTTPS (canonical host)
-server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
-    server_name www.inviteyou.ca;
-
-    # Reuse the existing certbot-managed certificate (must cover apex + www).
-    ssl_certificate     /etc/letsencrypt/live/inviteyou.ca/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/inviteyou.ca/privkey.pem;
-
-    return 301 https://inviteyou.ca$request_uri;
-}
-
-# Serve the static marketing site on the apex domain
-server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
     server_name inviteyou.ca;
 
     root /var/www/inviteyou-web;
     index index.html;
 
-    ssl_certificate     /etc/letsencrypt/live/inviteyou.ca/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/inviteyou.ca/privkey.pem;
-
-    # Clean URLs: /about -> /about.html, plus normal file/dir handling.
+    # Clean URLs: /about -> /about.html
     location / {
         try_files $uri $uri.html $uri/ =404;
     }
 
-    # Long cache for static assets
     location ~* \.(?:css|js|png|jpg|jpeg|gif|svg|ico|woff2?)$ {
         expires 30d;
         add_header Cache-Control "public";
     }
+
+    listen 443 ssl;
+    ssl_certificate /etc/letsencrypt/live/inviteyou.ca-0001/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/inviteyou.ca-0001/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}
+
+# Apex HTTP -> HTTPS
+server {
+    if ($host = inviteyou.ca) {
+        return 301 https://$host$request_uri;
+    }
+
+    server_name inviteyou.ca;
+    listen 80;
+    return 404;
+}
+
+# www.inviteyou.ca -> redirect to apex (exact match overrides the *.inviteyou.ca wildcard)
+server {
+    listen 443 ssl;
+    server_name www.inviteyou.ca;
+
+    ssl_certificate /etc/letsencrypt/live/inviteyou.ca-0002/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/inviteyou.ca-0002/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    return 301 https://inviteyou.ca$request_uri;
+}
+
+# ---------------------------------------------------------------------------
+# Everything below is UNCHANGED from the original config:
+#   - k-golf.inviteyou.ca  (proxy to :8082)
+#   - *.inviteyou.ca       (proxy to :8080 — still serves we. / api. / etc.)
+# ---------------------------------------------------------------------------
+
+server {
+    listen 443 ssl http2;
+    server_name k-golf.inviteyou.ca;
+
+    ssl_certificate /etc/letsencrypt/live/inviteyou.ca-0002/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/inviteyou.ca-0002/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    # Hardening
+    add_header X-Frame-Options SAMEORIGIN;
+    add_header X-Content-Type-Options nosniff;
+    add_header Referrer-Policy strict-origin-when-cross-origin;
+    add_header X-XSS-Protection "1; mode=block";
+    add_header Cross-Origin-Opener-Policy same-origin always;
+    add_header Cross-Origin-Resource-Policy same-origin always;
+    add_header Cross-Origin-Embedder-Policy require-corp always;
+
+    # All traffic goes to backend (serves both frontend static files and API)
+    location / {
+        proxy_pass http://127.0.0.1:8082/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection upgrade;
+        proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 60s;
+    }
+}
+
+server {
+
+    server_name *.inviteyou.ca;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header  X-Real-IP $remote_addr;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    location /list {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header  X-Real-IP $remote_addr;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    listen 443 ssl;
+    ssl_certificate /etc/letsencrypt/live/inviteyou.ca-0002/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/inviteyou.ca-0002/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}
+
+server {
+    if ($host ~ ^(?<name>.+)\.inviteyou\.ca$) {
+        return 301 https://$host$request_uri;
+    }
+
+    server_name *.inviteyou.ca;
+    listen 80;
+    return 404;
 }

--- a/marketing/portfolio.html
+++ b/marketing/portfolio.html
@@ -1,0 +1,330 @@
+<!DOCTYPE html><html class="scroll-smooth" lang="en"><head>
+<meta charset="utf-8">
+<meta content="width=device-width, initial-scale=1.0" name="viewport">
+<title>Portfolio | InviteYou.ca - Featured Engagements</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;600;700;800&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@500&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet">
+<script id="tailwind-config">
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            "colors": {
+                    "on-primary-fixed": "#00174b",
+                    "on-background": "#181c20",
+                    "tertiary-container": "#b35052",
+                    "on-secondary": "#ffffff",
+                    "primary": "#004cca",
+                    "surface-container-high": "#e5e8ee",
+                    "on-tertiary-fixed": "#410007",
+                    "inverse-on-surface": "#eef1f6",
+                    "tertiary": "#94393b",
+                    "electric-blue": "#0062FF",
+                    "tertiary-fixed-dim": "#ffb3b1",
+                    "on-tertiary-container": "#fff1ef",
+                    "on-surface-variant": "#424656",
+                    "ghost-white": "#F8F9FA",
+                    "on-error": "#ffffff",
+                    "background": "#f7f9ff",
+                    "primary-fixed-dim": "#b4c5ff",
+                    "surface-tint": "#0053da",
+                    "on-secondary-fixed": "#002116",
+                    "tertiary-fixed": "#ffdad8",
+                    "inverse-primary": "#b4c5ff",
+                    "surface-container-highest": "#e0e3e8",
+                    "surface-container-low": "#f1f4f9",
+                    "surface-container": "#ebeef3",
+                    "inverse-surface": "#2d3135",
+                    "on-tertiary": "#ffffff",
+                    "surface": "#f7f9ff",
+                    "secondary-fixed": "#67fcc6",
+                    "secondary-container": "#67fcc6",
+                    "on-secondary-container": "#007354",
+                    "error-container": "#ffdad6",
+                    "on-error-container": "#93000a",
+                    "error": "#ba1a1a",
+                    "outline-variant": "#c2c6d9",
+                    "surface-variant": "#e0e3e8",
+                    "on-primary-fixed-variant": "#003ea8",
+                    "primary-container": "#0062ff",
+                    "on-tertiary-fixed-variant": "#7f292c",
+                    "primary-fixed": "#dbe1ff",
+                    "surface-bright": "#f7f9ff",
+                    "on-secondary-fixed-variant": "#00513a",
+                    "on-primary": "#ffffff",
+                    "secondary": "#006c4f",
+                    "on-surface": "#181c20",
+                    "surface-container-lowest": "#ffffff",
+                    "surface-dim": "#d7dadf",
+                    "secondary-fixed-dim": "#44dfab",
+                    "on-primary-container": "#f3f3ff",
+                    "soft-teal": "#20C997",
+                    "surface-subtle": "#FBF2F2",
+                    "outline": "#737687"
+            },
+            "borderRadius": {
+                    "DEFAULT": "0.25rem",
+                    "lg": "0.5rem",
+                    "xl": "0.75rem",
+                    "full": "9999px"
+            },
+            "spacing": {
+                    "margin-mobile": "16px",
+                    "unit": "4px",
+                    "max-width": "1280px",
+                    "margin-desktop": "64px",
+                    "gutter": "24px"
+            },
+            "fontFamily": {
+                    "headline-md": ["Hanken Grotesk"],
+                    "label-md": ["JetBrains Mono"],
+                    "body-md": ["Inter"],
+                    "label-sm": ["JetBrains Mono"],
+                    "headline-lg": ["Hanken Grotesk"],
+                    "headline-xl": ["Hanken Grotesk"],
+                    "headline-lg-mobile": ["Hanken Grotesk"],
+                    "body-lg": ["Inter"]
+            },
+            "fontSize": {
+                    "headline-md": ["32px", {"lineHeight": "40px", "fontWeight": "600"}],
+                    "label-md": ["14px", {"lineHeight": "20px", "letterSpacing": "0.05em", "fontWeight": "500"}],
+                    "body-md": ["16px", {"lineHeight": "24px", "fontWeight": "400"}],
+                    "label-sm": ["12px", {"lineHeight": "16px", "letterSpacing": "0.05em", "fontWeight": "500"}],
+                    "headline-lg": ["48px", {"lineHeight": "56px", "letterSpacing": "-0.01em", "fontWeight": "600"}],
+                    "headline-xl": ["64px", {"lineHeight": "72px", "letterSpacing": "-0.02em", "fontWeight": "700"}],
+                    "headline-lg-mobile": ["32px", {"lineHeight": "40px", "fontWeight": "600"}],
+                    "body-lg": ["18px", {"lineHeight": "28px", "fontWeight": "400"}]
+            }
+          },
+        },
+      }
+    </script>
+<style>
+        .material-symbols-outlined {
+            font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+            vertical-align: middle;
+        }
+        .perspective-1000 { perspective: 1000px; }
+        .tilt-card {
+            transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+            transform-style: preserve-3d;
+        }
+        .glass-nav {
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+        }
+    </style>
+</head>
+<body class="bg-background text-on-background font-body-md selection:bg-electric-blue selection:text-white">
+<!-- TopNavBar -->
+<header class="fixed top-0 left-0 w-full z-50 bg-surface/70 backdrop-blur-xl shadow-sm">
+<div class="flex justify-between items-center max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-4">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary tracking-tight" style="cursor:pointer">InviteYou.ca</a>
+<nav class="hidden md:flex items-center space-x-8">
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="services.html">Services</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="solutions.html">Solutions</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="process.html">Process</a>
+<a class="text-primary border-b-2 border-primary pb-1 font-semibold font-label-md text-label-md" href="portfolio.html">Portfolio</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="about.html">About</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="contact.html">Contact</a>
+</nav>
+<a href="contact.html"><button class="bg-primary-container text-on-primary-container px-6 py-2.5 rounded-full font-label-md text-label-md hover:scale-105 hover:shadow-md transition-all duration-200 active:scale-95">Get Started</button></a>
+</div>
+</header>
+<main class="pt-20">
+<!-- Hero Section -->
+<section class="relative overflow-hidden py-24 md:py-32">
+
+<div class="relative z-10 px-margin-mobile md:px-margin-desktop max-w-max-width mx-auto text-center">
+<span class="inline-block px-4 py-1.5 mb-6 bg-primary-fixed text-on-primary-fixed-variant font-label-md rounded-full tracking-wider">FEATURED ENGAGEMENTS</span>
+<h1 class="font-headline-xl text-headline-xl mb-6 tracking-tight">Transforming Enterprise <span class="text-electric-blue">Landscapes</span></h1>
+<p class="font-body-lg text-body-lg text-on-surface-variant max-w-2xl mx-auto mb-10 leading-relaxed">
+                    We partner with global leaders to engineer digital products that redefine industries, from complex financial dashboards to seamless logistics ecosystems.
+                </p>
+<div class="flex flex-col sm:flex-row justify-center gap-4">
+<button class="px-8 py-4 bg-electric-blue text-white rounded-lg font-bold hover:shadow-xl hover:-translate-y-1 transition-all duration-300">Start Your Project</button>
+<button class="px-8 py-4 border-2 border-electric-blue text-electric-blue rounded-lg font-bold hover:bg-electric-blue/5 transition-all duration-300">View Methodology</button>
+</div>
+</div>
+</section>
+<!-- Portfolio Grid Section -->
+<section class="py-24 bg-surface-container-lowest">
+<div class="px-margin-mobile md:px-margin-desktop max-w-max-width mx-auto">
+<div class="flex flex-col md:flex-row md:items-end justify-between gap-6 mb-16">
+<div>
+<h2 class="font-headline-lg text-headline-lg mb-4">Selected Portfolio</h2>
+<p class="text-on-surface-variant font-body-md max-w-xl">A curated deep-dive into high-impact solutions that deliver measurable ROI for our B2B partners.</p>
+</div>
+<div class="flex gap-4">
+<button class="p-2 border border-outline rounded-full hover:bg-surface-variant transition-colors"><span class="material-symbols-outlined">grid_view</span></button>
+<button class="p-2 border border-outline rounded-full hover:bg-surface-variant transition-colors"><span class="material-symbols-outlined">filter_list</span></button>
+</div>
+</div>
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-12 perspective-1000">
+<!-- Project Card 1: Nexus Analytics Platform -->
+<div class="tilt-card group cursor-pointer transition-all duration-700 ease-out opacity-100 translate-y-0">
+<div class="relative overflow-hidden rounded-xl bg-white shadow-sm border border-outline-variant/30 group-hover:shadow-xl transition-all duration-500">
+<div class="aspect-[16/9] w-full overflow-hidden">
+<img class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-700" data-alt="A sophisticated financial technology dashboard displayed on a high-resolution professional monitor. The UI features complex data visualizations, dark-mode analytics graphs with electric blue highlights, and real-time market data tickers. The setting is a clean, minimalist corporate office with soft ambient lighting and a futuristic aesthetic, emphasizing precision and trust." src="https://lh3.googleusercontent.com/aida-public/AB6AXuCp9WIWL-O5lAcmgDeXenlF8qFu9idSOEjqIXFUh7WTntGDaoBkVjQ8XgNklsTJ3ldvJ0el4nFmb2z7PcZGB79Ubdli5EfLaFiQEV8mOjBPqFNf8Q59it834p1w_sLEA1mEeHl3BF7-MfMsPqUixfMb-0wnbkOsTrwr7A2daJxkoyDexDIe3kWw0_UjWH2dU42gfH4Wxz0frMXJtQbDSn_onqTlyEF3KGJVK9DOwmTFxXfIovSQ3m-hwZdXVB4Hmslw4SmFAnmpIDg">
+</div>
+<div class="p-8">
+<div class="flex gap-2 mb-4">
+<span class="px-3 py-1 bg-primary/10 text-primary font-label-sm rounded-full">FINTECH</span>
+<span class="px-3 py-1 bg-primary/10 text-primary font-label-sm rounded-full">DASHBOARD</span>
+</div>
+<h3 class="font-headline-md text-headline-md mb-3 group-hover:text-electric-blue transition-colors">Nexus Analytics Platform</h3>
+<p class="text-on-surface-variant mb-6 leading-relaxed">A real-time data engine for institutional investors, consolidating fragmented market feeds into a unified AI-driven intelligence layer.</p>
+<div class="flex items-center text-electric-blue font-bold gap-2">
+<span class="">Explore Project</span>
+<span class="material-symbols-outlined text-sm">arrow_forward</span>
+</div>
+</div>
+</div>
+</div>
+<!-- Project Card 2: RouteSync Mobile -->
+<div class="tilt-card group cursor-pointer transition-all duration-700 ease-out opacity-100 translate-y-0">
+<div class="relative overflow-hidden rounded-xl bg-white shadow-sm border border-outline-variant/30 group-hover:shadow-xl transition-all duration-500">
+<div class="aspect-[16/9] w-full overflow-hidden">
+<img class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-700" data-alt="A modern logistics and fleet management mobile application shown in a studio lighting setup. The screen displays a sleek map-based interface with dynamic route optimization paths in glowing electric blue. The aesthetic is ultra-modern and high-tech, with a focus on usability and clarity. Background is a soft-focus architectural space with cool neutral tones." src="https://lh3.googleusercontent.com/aida-public/AB6AXuB09uF-jGV2_-O1oJ3w0UpkHfmCfWaAg2RNS0AU7aZ8q97sVMpqV-WzAX0R9q-PiXwvkmZeRI8oq62DzxfEycwbP1lwj1DWtG7F_j9f3jt8xdpyOBaoH5aKYc0Y8tNTwbGajhV2SFbexgMK9LupjtzXjxem9gxLimxSjtCPKfXsKExyQ9biz34F3R78RmQCzrs7PIWXhYII5Ytu2gxiTSE5hljO-DFO1NkeiJyGQ6RqiV2-B8lpNFrZ9E0_3pct7OesxFvnbH_1ups">
+</div>
+<div class="p-8">
+<div class="flex gap-2 mb-4">
+<span class="px-3 py-1 bg-secondary/10 text-secondary font-label-sm rounded-full">LOGISTICS</span>
+<span class="px-3 py-1 bg-secondary/10 text-secondary font-label-sm rounded-full">MOBILE APP</span>
+</div>
+<h3 class="font-headline-md text-headline-md mb-3 group-hover:text-electric-blue transition-colors">RouteSync Mobile</h3>
+<p class="text-on-surface-variant mb-6 leading-relaxed">Streamlining last-mile delivery through dynamic route optimization and real-time fleet synchronization for global logistics providers.</p>
+<div class="flex items-center text-electric-blue font-bold gap-2">
+<span class="">Explore Project</span>
+<span class="material-symbols-outlined text-sm">arrow_forward</span>
+</div>
+</div>
+</div>
+</div>
+<!-- Project Card 3: CloudSphere ERP -->
+<div class="tilt-card group cursor-pointer lg:col-span-2 transition-all duration-700 ease-out opacity-100 translate-y-0">
+<div class="flex flex-col lg:flex-row relative overflow-hidden rounded-xl bg-white shadow-sm border border-outline-variant/30 group-hover:shadow-xl transition-all duration-500">
+<div class="lg:w-3/5 aspect-[16/9] lg:aspect-auto overflow-hidden">
+<img class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-700" data-alt="An expansive view of a cloud-based enterprise resource planning software interface on a widescreen display. The design uses a clean white background with subtle gray dividers and vibrant blue interactive elements. The scene conveys a sense of high-level organization and operational efficiency. The environment is a bright, high-key workspace with minimalist furniture." src="https://lh3.googleusercontent.com/aida-public/AB6AXuD1Rr-JDQJ8IYImY7K07m88McWW-eF-WUj0Lyzp7nG2CApEv2iPXGmfXVZR4ilOPfz4q-KzsK5s_0vJOI2grwRNmLNvihan7fzYRGapEaTiBiBNiwmcuc_Ycy3bumYXU61mL4yKXikqfULZXW1fdv--bkzDoBMzAvmEMXa9wltZ7s9MtwQBHgi-a2WMjLFCjrjlW4lm7oZn79Szibextjc0P-7W5NE63ASOrITw2bRN0Qrxkn_ed9Yovm-mCysK47V7ag67-zDAwGI">
+</div>
+<div class="lg:w-2/5 p-8 lg:p-12 flex flex-col justify-center">
+<div class="flex gap-2 mb-4">
+<span class="px-3 py-1 bg-tertiary/10 text-tertiary font-label-sm rounded-full">ENTERPRISE</span>
+<span class="px-3 py-1 bg-tertiary/10 text-tertiary font-label-sm rounded-full">SAAS</span>
+</div>
+<h3 class="font-headline-md text-headline-md mb-4 group-hover:text-electric-blue transition-colors">CloudSphere ERP</h3>
+<p class="text-on-surface-variant mb-8 leading-relaxed">Revolutionizing internal operations for manufacturing giants with a scalable, cloud-native resource management ecosystem.</p>
+<div class="flex items-center text-electric-blue font-bold gap-2">
+<span class="">Explore Project</span>
+<span class="material-symbols-outlined text-sm">arrow_forward</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+<!-- CTA Section -->
+<section class="py-24 px-margin-mobile md:px-margin-desktop bg-inverse-surface text-inverse-on-surface">
+<div class="max-w-max-width mx-auto rounded-3xl overflow-hidden relative">
+<div class="relative z-10 p-12 md:p-24 text-center">
+<h2 class="font-headline-lg text-headline-lg mb-8">Ready to build your next breakthrough?</h2>
+<p class="font-body-lg text-body-lg text-surface-variant max-w-xl mx-auto mb-12">Join the ranks of enterprises that have scaled their digital potential with InviteYou.ca.</p>
+<button class="px-10 py-5 bg-electric-blue text-white rounded-full font-bold text-lg hover:shadow-[0_0_30px_rgba(0,98,255,0.4)] hover:scale-105 transition-all duration-300">Schedule a Strategy Session</button>
+</div>
+<div class="absolute inset-0 opacity-10">
+
+</div>
+</div>
+</section>
+</main>
+<!-- Footer -->
+<footer class="w-full bg-surface-container-lowest border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-16 grid grid-cols-2 md:grid-cols-4 gap-8">
+<div class="col-span-2 md:col-span-1">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary" style="cursor:pointer">InviteYou.ca</a>
+<p class="font-body-md text-body-md text-on-surface-variant mt-4 max-w-xs">Architecting custom business solutions with high-tech innovation and institutional reliability.</p>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Company</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="about.html">About</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="careers.html">Careers</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Contact</a></li>
+</ul>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Expertise</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="services.html">Services</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="solutions.html">Solutions</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="process.html">Process</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="portfolio.html">Portfolio</a></li>
+</ul>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Support</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="faq.html">FAQ</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Contact</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Get Started</a></li>
+</ul>
+</div>
+</div>
+<div class="border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-6 flex flex-col md:flex-row justify-between items-center gap-4">
+<p class="font-label-sm text-label-sm text-on-surface-variant">© 2024 InviteYou.ca Business Solutions. All rights reserved.</p>
+<div class="flex flex-wrap justify-center gap-6">
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Privacy Policy</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Terms of Service</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Cookie Policy</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Sitemap</a>
+</div>
+</div>
+</div>
+</footer>
+<script>
+        // Hover-Tilt Effect for Portfolio Cards
+        document.querySelectorAll('.tilt-card').forEach(card => {
+            card.addEventListener('mousemove', (e) => {
+                const rect = card.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                
+                const centerX = rect.width / 2;
+                const centerY = rect.height / 2;
+                
+                const rotateX = (y - centerY) / 25;
+                const rotateY = (centerX - x) / 25;
+                
+                card.querySelector('.relative').style.transform = `rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;
+            });
+            
+            card.addEventListener('mouseleave', () => {
+                card.querySelector('.relative').style.transform = 'rotateX(0deg) rotateY(0deg)';
+            });
+        });
+
+        // Intersection Observer for reveal animations
+        const revealCallback = (entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('opacity-100', 'translate-y-0');
+                    entry.target.classList.remove('opacity-0', 'translate-y-10');
+                }
+            });
+        };
+
+        const observer = new IntersectionObserver(revealCallback, { threshold: 0.1 });
+        document.querySelectorAll('.tilt-card').forEach(el => {
+            el.classList.add('opacity-0', 'translate-y-10', 'transition-all', 'duration-700', 'ease-out');
+            observer.observe(el);
+        });
+    </script>
+
+
+
+
+</body></html>

--- a/marketing/process.html
+++ b/marketing/process.html
@@ -1,0 +1,382 @@
+<!DOCTYPE html><html class="scroll-smooth" lang="en"><head>
+<meta charset="utf-8">
+<meta content="width=device-width, initial-scale=1.0" name="viewport">
+<title>Process - InviteYou.ca</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;600;700;800&amp;family=Inter:wght@400;500&amp;family=JetBrains+Mono:wght@500&amp;family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@100..900&amp;family=Inter:wght@100..900&amp;family=JetBrains+Mono:wght@100..900&amp;display=swap" rel="stylesheet">
+<script id="tailwind-config">
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            "colors": {
+                    "secondary-fixed-dim": "#44dfab",
+                    "surface-container-highest": "#e0e3e8",
+                    "surface-container-high": "#e5e8ee",
+                    "secondary-container": "#67fcc6",
+                    "outline-variant": "#c2c6d9",
+                    "electric-blue": "#0062FF",
+                    "surface": "#f7f9ff",
+                    "on-secondary-fixed": "#002116",
+                    "ghost-white": "#F8F9FA",
+                    "tertiary-container": "#b35052",
+                    "inverse-on-surface": "#eef1f6",
+                    "surface-container": "#ebeef3",
+                    "on-secondary": "#ffffff",
+                    "error-container": "#ffdad6",
+                    "on-tertiary": "#ffffff",
+                    "primary-fixed-dim": "#b4c5ff",
+                    "inverse-surface": "#2d3135",
+                    "secondary-fixed": "#67fcc6",
+                    "on-primary-fixed-variant": "#003ea8",
+                    "surface-bright": "#f7f9ff",
+                    "outline": "#737687",
+                    "tertiary": "#94393b",
+                    "tertiary-fixed": "#ffdad8",
+                    "primary": "#004cca",
+                    "error": "#ba1a1a",
+                    "on-error": "#ffffff",
+                    "surface-subtle": "#FBF2F2",
+                    "surface-tint": "#0053da",
+                    "on-surface-variant": "#424656",
+                    "soft-teal": "#20C997",
+                    "on-secondary-container": "#007354",
+                    "secondary": "#006c4f",
+                    "on-secondary-fixed-variant": "#00513a",
+                    "inverse-primary": "#b4c5ff",
+                    "on-primary-fixed": "#00174b",
+                    "on-tertiary-fixed-variant": "#7f292c",
+                    "on-background": "#181c20",
+                    "surface-container-low": "#f1f4f9",
+                    "surface-variant": "#e0e3e8",
+                    "on-error-container": "#93000a",
+                    "surface-container-lowest": "#ffffff",
+                    "background": "#f7f9ff",
+                    "on-primary": "#ffffff",
+                    "on-tertiary-fixed": "#410007",
+                    "primary-container": "#0062ff",
+                    "surface-dim": "#d7dadf",
+                    "on-primary-container": "#f3f3ff",
+                    "primary-fixed": "#dbe1ff",
+                    "on-tertiary-container": "#fff1ef",
+                    "on-surface": "#181c20",
+                    "tertiary-fixed-dim": "#ffb3b1"
+            },
+            "borderRadius": {
+                    "DEFAULT": "0.25rem",
+                    "lg": "0.5rem",
+                    "xl": "0.75rem",
+                    "full": "9999px"
+            },
+            "spacing": {
+                    "margin-mobile": "16px",
+                    "margin-desktop": "64px",
+                    "unit": "4px",
+                    "max-width": "1280px",
+                    "gutter": "24px"
+            },
+            "fontFamily": {
+                    "label-md": ["JetBrains Mono"],
+                    "headline-xl": ["Hanken Grotesk"],
+                    "headline-lg-mobile": ["Hanken Grotesk"],
+                    "body-md": ["Inter"],
+                    "headline-md": ["Hanken Grotesk"],
+                    "headline-lg": ["Hanken Grotesk"],
+                    "body-lg": ["Inter"],
+                    "label-sm": ["JetBrains Mono"]
+            },
+            "fontSize": {
+                    "label-md": ["14px", {"lineHeight": "20px", "letterSpacing": "0.05em", "fontWeight": "500"}],
+                    "headline-xl": ["64px", {"lineHeight": "72px", "letterSpacing": "-0.02em", "fontWeight": "700"}],
+                    "headline-lg-mobile": ["32px", {"lineHeight": "40px", "fontWeight": "600"}],
+                    "body-md": ["16px", {"lineHeight": "24px", "fontWeight": "400"}],
+                    "headline-md": ["32px", {"lineHeight": "40px", "fontWeight": "600"}],
+                    "headline-lg": ["48px", {"lineHeight": "56px", "letterSpacing": "-0.01em", "fontWeight": "600"}],
+                    "body-lg": ["18px", {"lineHeight": "28px", "fontWeight": "400"}],
+                    "label-sm": ["12px", {"lineHeight": "16px", "letterSpacing": "0.05em", "fontWeight": "500"}]
+            }
+          },
+        },
+      }
+    </script>
+<style>
+        .glass-nav {
+            background: rgba(255, 255, 255, 0.7);
+            backdrop-filter: blur(20px);
+            -webkit-backdrop-filter: blur(20px);
+        }
+        .timeline-line {
+            background: linear-gradient(to bottom, #0062FF 0%, #0062FF 50%, #e0e3e8 50%, #e0e3e8 100%);
+            background-size: 100% 200%;
+            background-position: bottom;
+            transition: background-position 0.5s ease;
+        }
+        .timeline-item.active .timeline-line {
+            background-position: top;
+        }
+        .reveal-on-scroll {
+            opacity: 0;
+            transform: translateY(20px);
+            transition: all 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+        }
+        .reveal-on-scroll.visible {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    </style>
+</head>
+<body class="bg-background text-on-background font-body-md selection:bg-electric-blue/20">
+<!-- TopNavBar -->
+<header class="fixed top-0 left-0 w-full z-50 bg-surface/70 backdrop-blur-xl shadow-sm">
+<div class="flex justify-between items-center max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-4">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary tracking-tight" style="cursor:pointer">InviteYou.ca</a>
+<nav class="hidden md:flex items-center space-x-8">
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="services.html">Services</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="solutions.html">Solutions</a>
+<a class="text-primary border-b-2 border-primary pb-1 font-semibold font-label-md text-label-md" href="process.html">Process</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="portfolio.html">Portfolio</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="about.html">About</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="contact.html">Contact</a>
+</nav>
+<a href="contact.html"><button class="bg-primary-container text-on-primary-container px-6 py-2.5 rounded-full font-label-md text-label-md hover:scale-105 hover:shadow-md transition-all duration-200 active:scale-95">Get Started</button></a>
+</div>
+</header>
+<main class="pt-24">
+<!-- Hero Section -->
+<section class="relative min-h-[70vh] flex flex-col items-center justify-center text-center px-margin-mobile md:px-margin-desktop py-24 overflow-hidden">
+<div class="absolute inset-0 z-0 opacity-40">
+
+</div>
+<div class="relative z-10 max-w-4xl mx-auto space-y-6">
+<span class="inline-block px-4 py-1.5 bg-electric-blue/10 text-electric-blue rounded-full font-label-sm text-label-sm uppercase tracking-wider mb-4">Our Methodology</span>
+<h1 class="font-headline-xl text-headline-xl text-on-background md:text-[80px] leading-tight">
+                    The Path to <span class="text-electric-blue">Digital Excellence</span>
+</h1>
+<p class="font-body-lg text-body-lg text-on-surface-variant max-w-2xl mx-auto">
+                    A rigorous, transparent methodology designed to transform complex challenges into scalable enterprise solutions.
+                </p>
+</div>
+<div class="absolute bottom-12 left-1/2 -translate-x-1/2 animate-bounce">
+<span class="material-symbols-outlined text-primary text-3xl">expand_more</span>
+</div>
+</section>
+<!-- Process Timeline -->
+<section class="py-32 px-margin-mobile md:px-margin-desktop max-w-max-width mx-auto">
+<div class="grid grid-cols-1 lg:grid-cols-12 gap-12 relative">
+<!-- Sticky Navigation/Progress Side (Desktop) -->
+<div class="hidden lg:block lg:col-span-4 sticky top-40 h-fit space-y-8">
+<h2 class="font-headline-md text-headline-md">Five Stages of <br>Modern Transformation</h2>
+<div class="space-y-4">
+<div class="flex items-center gap-4 text-electric-blue">
+<span class="font-label-md text-label-md opacity-40">01</span>
+<span class="font-label-md text-label-md font-bold">Discovery</span>
+</div>
+<div class="flex items-center gap-4 text-on-surface-variant/40">
+<span class="font-label-md text-label-md">02</span>
+<span class="font-label-md text-label-md">Architecture</span>
+</div>
+<div class="flex items-center gap-4 text-on-surface-variant/40">
+<span class="font-label-md text-label-md">03</span>
+<span class="font-label-md text-label-md">Development</span>
+</div>
+<div class="flex items-center gap-4 text-on-surface-variant/40">
+<span class="font-label-md text-label-md">04</span>
+<span class="font-label-md text-label-md">Testing</span>
+</div>
+<div class="flex items-center gap-4 text-on-surface-variant/40">
+<span class="font-label-md text-label-md">05</span>
+<span class="font-label-md text-label-md">Deployment</span>
+</div>
+</div>
+</div>
+<!-- Main Vertical Timeline -->
+<div class="lg:col-span-8 space-y-32 relative">
+<!-- Vertical Line Connector -->
+<div class="absolute left-6 md:left-12 top-4 bottom-4 w-px bg-surface-container-highest z-0"></div>
+<!-- Phase 1 -->
+<div class="reveal-on-scroll relative flex gap-8 md:gap-16 items-start group visible">
+<div class="relative z-10 flex-shrink-0 w-12 h-12 md:w-24 md:h-24 bg-white rounded-2xl shadow-xl border border-surface-variant flex items-center justify-center transition-transform group-hover:scale-110">
+<span class="material-symbols-outlined text-electric-blue text-2xl md:text-4xl" data-icon="search">search</span>
+</div>
+<div class="space-y-4">
+<span class="font-label-sm text-label-sm text-electric-blue tracking-widest uppercase">Phase 1</span>
+<h3 class="font-headline-md text-headline-md text-on-background">Discovery &amp; Audit</h3>
+<p class="font-body-md text-body-md text-on-surface-variant leading-relaxed max-w-xl">
+                                We begin with a deep-dive into your existing business needs and technical infrastructure. This stage involves stakeholder interviews, data analysis, and technical debt assessments to identify every friction point and opportunity.
+                            </p>
+<div class="grid grid-cols-2 gap-4 mt-6">
+<div class="p-4 bg-surface-container-low rounded-xl border border-surface-variant/50">
+<p class="font-label-sm text-label-sm text-primary mb-1">Deliverable</p>
+<p class="font-body-md text-body-md font-semibold">Infrastructure Map</p>
+</div>
+<div class="p-4 bg-surface-container-low rounded-xl border border-surface-variant/50">
+<p class="font-label-sm text-label-sm text-primary mb-1">Focus</p>
+<p class="font-body-md text-body-md font-semibold">Gap Analysis</p>
+</div>
+</div>
+</div>
+</div>
+<!-- Phase 2 -->
+<div class="reveal-on-scroll relative flex gap-8 md:gap-16 items-start group visible">
+<div class="relative z-10 flex-shrink-0 w-12 h-12 md:w-24 md:h-24 bg-white rounded-2xl shadow-xl border border-surface-variant flex items-center justify-center transition-transform group-hover:scale-110">
+<span class="material-symbols-outlined text-electric-blue text-2xl md:text-4xl" data-icon="architecture">architecture</span>
+</div>
+<div class="space-y-4">
+<span class="font-label-sm text-label-sm text-electric-blue tracking-widest uppercase">Phase 2</span>
+<h3 class="font-headline-md text-headline-md text-on-background">Strategic Architecture</h3>
+<p class="font-body-md text-body-md text-on-surface-variant leading-relaxed max-w-xl">
+                                Foundations are everything. We design high-fidelity data models and security-first system architectures. This blueprint ensures that your solution isn't just functional, but inherently scalable and resilient against future threats.
+                            </p>
+<img class="w-full aspect-video object-cover rounded-2xl shadow-lg border border-surface-variant/30 mt-4" data-alt="A clean, minimalist 3D rendering of complex digital blueprints and data nodes connected by glowing blue lines in a bright white space, representing sophisticated system architecture." src="https://lh3.googleusercontent.com/aida-public/AB6AXuChwHqgSb_VojUj1gHrbaFC0VXzPJacXyFonN8_T7xJ8cDW2_HL59ldiqA_CxZUxAZD6O-R__Nly7ixVadYm-BRiTywM-Q3q0W82JLGfM0p98zV5W5y47CIsdaZGGnRgFijd_xwedmtjN1fB2AebAWH3sF08hwANL_m3b1RL4MkU01cDWsSB74FvoyKGA2mhQnb2ed6APtx5Muwgwn08p4I65aTSBKZD3do4DFn_dGOTgJw8nd1arDLg29fLJbQrV2GtNoREULLvTc">
+</div>
+</div>
+<!-- Phase 3 -->
+<div class="reveal-on-scroll relative flex gap-8 md:gap-16 items-start group visible">
+<div class="relative z-10 flex-shrink-0 w-12 h-12 md:w-24 md:h-24 bg-white rounded-2xl shadow-xl border border-surface-variant flex items-center justify-center transition-transform group-hover:scale-110">
+<span class="material-symbols-outlined text-electric-blue text-2xl md:text-4xl" data-icon="cycle">cycle</span>
+</div>
+<div class="space-y-4">
+<span class="font-label-sm text-label-sm text-electric-blue tracking-widest uppercase">Phase 3</span>
+<h3 class="font-headline-md text-headline-md text-on-background">Agile Development</h3>
+<p class="font-body-md text-body-md text-on-surface-variant leading-relaxed max-w-xl">
+                                We work in rapid, iterative sprints with bi-weekly check-ins. This transparent process allows you to see the product evolve in real-time, providing continuous feedback loops that keep the development aligned with business goals.
+                            </p>
+<div class="flex flex-wrap gap-2">
+<span class="px-3 py-1 bg-surface-variant/40 rounded-full font-label-sm text-label-sm text-on-surface-variant">2-WEEK SPRINTS</span>
+<span class="px-3 py-1 bg-surface-variant/40 rounded-full font-label-sm text-label-sm text-on-surface-variant">CI/CD PIPELINES</span>
+<span class="px-3 py-1 bg-surface-variant/40 rounded-full font-label-sm text-label-sm text-on-surface-variant">LUMINOUS UI</span>
+</div>
+</div>
+</div>
+<!-- Phase 4 -->
+<div class="reveal-on-scroll relative flex gap-8 md:gap-16 items-start group visible">
+<div class="relative z-10 flex-shrink-0 w-12 h-12 md:w-24 md:h-24 bg-white rounded-2xl shadow-xl border border-surface-variant flex items-center justify-center transition-transform group-hover:scale-110">
+<span class="material-symbols-outlined text-electric-blue text-2xl md:text-4xl" data-icon="verified">verified</span>
+</div>
+<div class="space-y-4">
+<span class="font-label-sm text-label-sm text-electric-blue tracking-widest uppercase">Phase 4</span>
+<h3 class="font-headline-md text-headline-md text-on-background">Rigorous Testing</h3>
+<p class="font-body-md text-body-md text-on-surface-variant leading-relaxed max-w-xl">
+                                Quality assurance is non-negotiable. Our team conducts automated and manual QA, comprehensive security audits, and peak-load performance optimization. We break things in our lab so they never break in your production.
+                            </p>
+</div>
+</div>
+<!-- Phase 5 -->
+<div class="reveal-on-scroll relative flex gap-8 md:gap-16 items-start group visible">
+<div class="relative z-10 flex-shrink-0 w-12 h-12 md:w-24 md:h-24 bg-electric-blue rounded-2xl shadow-xl flex items-center justify-center transition-transform group-hover:scale-110">
+<span class="material-symbols-outlined text-white text-2xl md:text-4xl" data-icon="rocket_launch">rocket_launch</span>
+</div>
+<div class="space-y-4">
+<span class="font-label-sm text-label-sm text-electric-blue tracking-widest uppercase">Phase 5</span>
+<h3 class="font-headline-md text-headline-md text-on-background">Deployment &amp; Scaling</h3>
+<p class="font-body-md text-body-md text-on-surface-variant leading-relaxed max-w-xl">
+                                We handle the seamless rollout of your solution, ensuring zero downtime. Post-launch, we provide 24/7 monitoring and proactive scaling support to ensure your technology grows as fast as your business does.
+                            </p>
+<div class="p-6 bg-electric-blue text-white rounded-2xl shadow-lg mt-4 flex items-center justify-between">
+<div>
+<p class="font-headline-md text-headline-md">99.9%</p>
+<p class="font-label-sm text-label-sm opacity-80 uppercase">Uptime Commitment</p>
+</div>
+<span class="material-symbols-outlined text-5xl opacity-20">cloud_done</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+<!-- Final CTA Section -->
+<section class="py-32 px-margin-mobile md:px-margin-desktop text-center bg-surface-container-low">
+<div class="max-w-3xl mx-auto space-y-8">
+<h2 class="font-headline-lg text-headline-lg text-on-background">Start Your Journey with Us</h2>
+<p class="font-body-lg text-body-lg text-on-surface-variant">
+                    Ready to transform your enterprise infrastructure with a methodology that prioritizes precision and performance?
+                </p>
+<div class="flex flex-col md:flex-row items-center justify-center gap-4 pt-4">
+<button class="w-full md:w-auto bg-electric-blue text-white px-8 py-4 rounded-full font-label-md text-label-md hover:scale-105 hover:shadow-xl transition-all duration-300">
+                        Book a Consultation
+                    </button>
+<button class="w-full md:w-auto border-2 border-electric-blue text-electric-blue px-8 py-4 rounded-full font-label-md text-label-md hover:bg-electric-blue/5 transition-all duration-300">
+                        View Our Work
+                    </button>
+</div>
+</div>
+</section>
+</main>
+<!-- Footer -->
+<footer class="w-full bg-surface-container-lowest border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-16 grid grid-cols-2 md:grid-cols-4 gap-8">
+<div class="col-span-2 md:col-span-1">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary" style="cursor:pointer">InviteYou.ca</a>
+<p class="font-body-md text-body-md text-on-surface-variant mt-4 max-w-xs">Architecting custom business solutions with high-tech innovation and institutional reliability.</p>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Company</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="about.html">About</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="careers.html">Careers</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Contact</a></li>
+</ul>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Expertise</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="services.html">Services</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="solutions.html">Solutions</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="process.html">Process</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="portfolio.html">Portfolio</a></li>
+</ul>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Support</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="faq.html">FAQ</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Contact</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Get Started</a></li>
+</ul>
+</div>
+</div>
+<div class="border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-6 flex flex-col md:flex-row justify-between items-center gap-4">
+<p class="font-label-sm text-label-sm text-on-surface-variant">© 2024 InviteYou.ca Business Solutions. All rights reserved.</p>
+<div class="flex flex-wrap justify-center gap-6">
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Privacy Policy</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Terms of Service</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Cookie Policy</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Sitemap</a>
+</div>
+</div>
+</div>
+</footer>
+<script>
+        // Intersection Observer for scroll animations
+        const observerOptions = {
+            threshold: 0.1,
+            rootMargin: '0px 0px -100px 0px'
+        };
+
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('visible');
+                    // Find corresponding side nav item if needed
+                }
+            });
+        }, observerOptions);
+
+        document.querySelectorAll('.reveal-on-scroll').forEach(el => observer.observe(el));
+
+        // Micro-interaction: Hover effects for timeline items
+        document.querySelectorAll('.reveal-on-scroll').forEach(item => {
+            item.addEventListener('mouseenter', () => {
+                item.querySelector('.material-symbols-outlined').style.transform = 'scale(1.2) rotate(5deg)';
+            });
+            item.addEventListener('mouseleave', () => {
+                item.querySelector('.material-symbols-outlined').style.transform = 'scale(1) rotate(0deg)';
+            });
+        });
+    </script>
+
+
+</body></html>

--- a/marketing/services.html
+++ b/marketing/services.html
@@ -1,0 +1,383 @@
+<!DOCTYPE html><html class="scroll-smooth" lang="en" style=""><head>
+<meta charset="utf-8">
+<meta content="width=device-width, initial-scale=1.0" name="viewport">
+<title>Our Capabilities | InviteYou.ca</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;600;700&amp;family=Inter:wght@400;500&amp;family=JetBrains+Mono:wght@500&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet">
+<!-- Tailwind Configuration -->
+<script id="tailwind-config">
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            "colors": {
+                "on-primary-fixed": "#00174b",
+                "on-background": "#181c20",
+                "tertiary-container": "#b35052",
+                "on-secondary": "#ffffff",
+                "primary": "#004cca",
+                "surface-container-high": "#e5e8ee",
+                "on-tertiary-fixed": "#410007",
+                "inverse-on-surface": "#eef1f6",
+                "tertiary": "#94393b",
+                "electric-blue": "#0062FF",
+                "tertiary-fixed-dim": "#ffb3b1",
+                "on-tertiary-container": "#fff1ef",
+                "on-surface-variant": "#424656",
+                "ghost-white": "#F8F9FA",
+                "on-error": "#ffffff",
+                "background": "#f7f9ff",
+                "primary-fixed-dim": "#b4c5ff",
+                "surface-tint": "#0053da",
+                "on-secondary-fixed": "#002116",
+                "tertiary-fixed": "#ffdad8",
+                "inverse-primary": "#b4c5ff",
+                "surface-container-highest": "#e0e3e8",
+                "surface-container-low": "#f1f4f9",
+                "surface-container": "#ebeef3",
+                "inverse-surface": "#2d3135",
+                "on-tertiary": "#ffffff",
+                "surface": "#f7f9ff",
+                "secondary-fixed": "#67fcc6",
+                "secondary-container": "#67fcc6",
+                "on-secondary-container": "#007354",
+                "error-container": "#ffdad6",
+                "on-error-container": "#93000a",
+                "error": "#ba1a1a",
+                "outline-variant": "#c2c6d9",
+                "surface-variant": "#e0e3e8",
+                "on-primary-fixed-variant": "#003ea8",
+                "primary-container": "#0062ff",
+                "on-tertiary-fixed-variant": "#7f292c",
+                "primary-fixed": "#dbe1ff",
+                "surface-bright": "#f7f9ff",
+                "on-secondary-fixed-variant": "#00513a",
+                "on-primary": "#ffffff",
+                "secondary": "#006c4f",
+                "on-surface": "#181c20",
+                "surface-container-lowest": "#ffffff",
+                "surface-dim": "#d7dadf",
+                "secondary-fixed-dim": "#44dfab",
+                "on-primary-container": "#f3f3ff",
+                "soft-teal": "#20C997",
+                "surface-subtle": "#FBF2F2",
+                "outline": "#737687"
+            },
+            "borderRadius": {
+                "DEFAULT": "0.25rem",
+                "lg": "0.5rem",
+                "xl": "0.75rem",
+                "full": "9999px"
+            },
+            "spacing": {
+                "margin-mobile": "16px",
+                "unit": "4px",
+                "max-width": "1280px",
+                "margin-desktop": "64px",
+                "gutter": "24px"
+            },
+            "fontFamily": {
+                "headline-md": ["Hanken Grotesk"],
+                "label-md": ["JetBrains Mono"],
+                "body-md": ["Inter"],
+                "label-sm": ["JetBrains Mono"],
+                "headline-lg": ["Hanken Grotesk"],
+                "headline-xl": ["Hanken Grotesk"],
+                "headline-lg-mobile": ["Hanken Grotesk"],
+                "body-lg": ["Inter"]
+            },
+            "fontSize": {
+                "headline-md": ["32px", {"lineHeight": "40px", "fontWeight": "600"}],
+                "label-md": ["14px", {"lineHeight": "20px", "letterSpacing": "0.05em", "fontWeight": "500"}],
+                "body-md": ["16px", {"lineHeight": "24px", "fontWeight": "400"}],
+                "label-sm": ["12px", {"lineHeight": "16px", "letterSpacing": "0.05em", "fontWeight": "500"}],
+                "headline-lg": ["48px", {"lineHeight": "56px", "letterSpacing": "-0.01em", "fontWeight": "600"}],
+                "headline-xl": ["64px", {"lineHeight": "72px", "letterSpacing": "-0.02em", "fontWeight": "700"}],
+                "headline-lg-mobile": ["32px", {"lineHeight": "40px", "fontWeight": "600"}],
+                "body-lg": ["18px", {"lineHeight": "28px", "fontWeight": "400"}]
+            }
+          },
+        },
+      }
+    </script>
+<style>
+        .glass-card {
+            background: rgba(255, 255, 255, 0.7);
+            backdrop-filter: blur(12px);
+            border: 1px solid rgba(233, 236, 239, 0.5);
+            transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+        }
+        .glass-card:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 20px 40px rgba(0, 0, 0, 0.04);
+        }
+        .reveal {
+            opacity: 0;
+            transform: translateY(30px);
+            transition: all 0.8s ease-out;
+        }
+        .reveal.active {
+            opacity: 1;
+            transform: translateY(0);
+        }
+        .scroll-parent {
+            perspective: 1000px;
+        }
+        .motion-blur-bg {
+            filter: blur(80px);
+            opacity: 0.15;
+            background: radial-gradient(circle at 50% 50%, #0062FF, #20C997);
+        }
+    </style>
+</head>
+<body class="bg-background text-on-background selection:bg-electric-blue/20">
+<!-- TopNavBar -->
+<header class="fixed top-0 left-0 w-full z-50 bg-surface/70 backdrop-blur-xl shadow-sm">
+<div class="flex justify-between items-center max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-4">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary tracking-tight" style="cursor:pointer">InviteYou.ca</a>
+<nav class="hidden md:flex items-center space-x-8">
+<a class="text-primary border-b-2 border-primary pb-1 font-semibold font-label-md text-label-md" href="services.html">Services</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="solutions.html">Solutions</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="process.html">Process</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="portfolio.html">Portfolio</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="about.html">About</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="contact.html">Contact</a>
+</nav>
+<a href="contact.html"><button class="bg-primary-container text-on-primary-container px-6 py-2.5 rounded-full font-label-md text-label-md hover:scale-105 hover:shadow-md transition-all duration-200 active:scale-95">Get Started</button></a>
+</div>
+</header>
+<main class="pt-20 overflow-hidden">
+<!-- Hero Section -->
+<section class="relative min-h-[716px] flex items-center justify-center py-24 md:py-32 px-margin-mobile md:px-margin-desktop">
+<!-- Subtle Motion-Blur Background -->
+<div class="absolute inset-0 pointer-events-none overflow-hidden">
+<div class="motion-blur-bg absolute -top-1/4 -left-1/4 w-[150%] h-[150%] animate-[spin_40s_linear_infinite]"></div>
+</div>
+<div class="relative z-10 max-w-[800px] text-center">
+<span class="inline-block px-4 py-1.5 rounded-full bg-electric-blue/10 text-electric-blue font-label-sm text-label-sm uppercase mb-8 tracking-widest animate-pulse">
+                    Expertise &amp; Vision
+                </span>
+<h1 class="font-headline-xl text-headline-xl md:text-headline-xl text-on-background mb-6 tracking-tight leading-none">
+                    Our <span class="text-electric-blue">Capabilities</span>
+</h1>
+<p class="font-body-lg text-body-lg text-on-surface-variant max-w-2xl mx-auto leading-relaxed">
+                    We architect future-proof digital systems that bridge the gap between complex engineering and human-centric design. Our multidisciplinary approach ensures your infrastructure scales as fast as your ambition.
+                </p>
+<div class="mt-12 flex flex-col sm:flex-row items-center justify-center gap-4">
+<button class="bg-electric-blue text-white px-8 py-4 rounded-lg font-label-md text-label-md hover:scale-105 transition-transform duration-300">
+                        Discuss Your Project
+                    </button>
+<button class="border border-electric-blue/30 text-electric-blue px-8 py-4 rounded-lg font-label-md text-label-md hover:bg-electric-blue/5 transition-all">View Portfolio</button>
+</div>
+</div>
+</section>
+<!-- Service Cards Section -->
+<section class="py-24 bg-white/40 border-y border-outline-variant/10">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop">
+<div class="grid grid-cols-1 md:grid-cols-3 gap-gutter">
+<!-- Digital Strategy Card -->
+<div id="digital-strategy" class="reveal glass-card p-10 rounded-xl group active scroll-mt-28" style="transition-delay: 100ms;">
+<div class="w-16 h-16 bg-primary/10 text-electric-blue rounded-lg flex items-center justify-center mb-8 group-hover:bg-electric-blue group-hover:text-white transition-colors duration-300">
+<span class="material-symbols-outlined text-[32px]" data-icon="insights">insights</span>
+</div>
+<h3 class="font-headline-md text-headline-md mb-4">Digital Strategy</h3>
+<p class="font-body-md text-body-md text-on-surface-variant mb-8 leading-relaxed">
+                            Mapping the technical roadmap for your organization's digital evolution. We align tech investment with business outcomes.
+                        </p>
+<a class="inline-flex items-center gap-2 text-electric-blue font-label-md text-label-md group-hover:gap-4 transition-all" href="contact.html">
+                            Learn More <span class="material-symbols-outlined text-[18px]" data-icon="arrow_forward">arrow_forward</span>
+</a>
+</div>
+<!-- Custom Tech Card -->
+<div id="custom-tech" class="reveal glass-card p-10 rounded-xl group border-2 border-electric-blue/10 active scroll-mt-28" style="transition-delay: 200ms;">
+<div class="w-16 h-16 bg-primary/10 text-electric-blue rounded-lg flex items-center justify-center mb-8 group-hover:bg-electric-blue group-hover:text-white transition-colors duration-300">
+<span class="material-symbols-outlined text-[32px]" data-icon="terminal">terminal</span>
+</div>
+<h3 class="font-headline-md text-headline-md mb-4">Custom Tech</h3>
+<p class="font-body-md text-body-md text-on-surface-variant mb-8 leading-relaxed">
+                            High-performance software development tailored to unique operational demands. From microservices to legacy migration.
+                        </p>
+<a class="inline-flex items-center gap-2 text-electric-blue font-label-md text-label-md group-hover:gap-4 transition-all" href="contact.html">
+                            Learn More <span class="material-symbols-outlined text-[18px]" data-icon="arrow_forward">arrow_forward</span>
+</a>
+</div>
+<!-- UX/UI Design Card -->
+<div id="ux-ui-design" class="reveal glass-card p-10 rounded-xl group active scroll-mt-28" style="transition-delay: 300ms;">
+<div class="w-16 h-16 bg-primary/10 text-electric-blue rounded-lg flex items-center justify-center mb-8 group-hover:bg-electric-blue group-hover:text-white transition-colors duration-300">
+<span class="material-symbols-outlined text-[32px]" data-icon="draw">draw</span>
+</div>
+<h3 class="font-headline-md text-headline-md mb-4">UX/UI Design</h3>
+<p class="font-body-md text-body-md text-on-surface-variant mb-8 leading-relaxed">
+                            Intuitive interfaces designed with clinical precision. We prioritize clarity, performance, and user retention.
+                        </p>
+<a class="inline-flex items-center gap-2 text-electric-blue font-label-md text-label-md group-hover:gap-4 transition-all" href="contact.html">
+                            Learn More <span class="material-symbols-outlined text-[18px]" data-icon="arrow_forward">arrow_forward</span>
+</a>
+</div>
+</div>
+</div>
+</section>
+<!-- Tech Stack Section -->
+<section class="py-32 bg-surface">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop text-center">
+<h2 class="font-headline-md text-headline-md mb-4">Our Technology Stack</h2>
+<p class="font-body-md text-body-md text-on-surface-variant mb-16">Powering solutions with world-class enterprise technologies.</p>
+<div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-8 items-center opacity-70 grayscale hover:grayscale-0 transition-all duration-500">
+<!-- Cloud Logo Placeholder -->
+<div class="flex flex-col items-center gap-3 group">
+<div class="w-16 h-16 flex items-center justify-center rounded-xl bg-white shadow-sm group-hover:scale-110 transition-transform">
+<span class="material-symbols-outlined text-4xl text-electric-blue" data-icon="cloud">cloud</span>
+</div>
+<span class="font-label-sm text-label-sm">Cloud Infrastructure</span>
+</div>
+<!-- AI Logo Placeholder -->
+<div class="flex flex-col items-center gap-3 group">
+<div class="w-16 h-16 flex items-center justify-center rounded-xl bg-white shadow-sm group-hover:scale-110 transition-transform">
+<span class="material-symbols-outlined text-4xl text-soft-teal" data-icon="psychology">psychology</span>
+</div>
+<span class="font-label-sm text-label-sm">Applied AI</span>
+</div>
+<!-- Security Logo Placeholder -->
+<div class="flex flex-col items-center gap-3 group">
+<div class="w-16 h-16 flex items-center justify-center rounded-xl bg-white shadow-sm group-hover:scale-110 transition-transform">
+<span class="material-symbols-outlined text-4xl text-tertiary" data-icon="verified_user">verified_user</span>
+</div>
+<span class="font-label-sm text-label-sm">Cybersecurity</span>
+</div>
+<!-- Data Logo Placeholder -->
+<div class="flex flex-col items-center gap-3 group">
+<div class="w-16 h-16 flex items-center justify-center rounded-xl bg-white shadow-sm group-hover:scale-110 transition-transform">
+<span class="material-symbols-outlined text-4xl text-primary" data-icon="database">database</span>
+</div>
+<span class="font-label-sm text-label-sm">Data Architecture</span>
+</div>
+<!-- DevOps Logo Placeholder -->
+<div class="flex flex-col items-center gap-3 group">
+<div class="w-16 h-16 flex items-center justify-center rounded-xl bg-white shadow-sm group-hover:scale-110 transition-transform">
+<span class="material-symbols-outlined text-4xl text-on-surface-variant" data-icon="settings_suggest">settings_suggest</span>
+</div>
+<span class="font-label-sm text-label-sm">DevOps CI/CD</span>
+</div>
+<!-- Mobile Logo Placeholder -->
+<div class="flex flex-col items-center gap-3 group">
+<div class="w-16 h-16 flex items-center justify-center rounded-xl bg-white shadow-sm group-hover:scale-110 transition-transform">
+<span class="material-symbols-outlined text-4xl text-electric-blue" data-icon="smartphone">smartphone</span>
+</div>
+<span class="font-label-sm text-label-sm">Mobile Native</span>
+</div>
+</div>
+</div>
+</section>
+<!-- CTA Section -->
+<section class="py-24 px-margin-mobile">
+<div class="max-w-max-width mx-auto bg-inverse-surface rounded-[2rem] p-12 md:p-24 relative overflow-hidden text-center">
+<div class="absolute top-0 right-0 w-64 h-64 bg-electric-blue/20 blur-[100px] -mr-32 -mt-32"></div>
+<div class="absolute bottom-0 left-0 w-64 h-64 bg-soft-teal/10 blur-[100px] -ml-32 -mb-32"></div>
+<h2 class="font-headline-lg text-headline-lg-mobile md:text-headline-lg text-inverse-on-surface mb-6 relative z-10">Ready to build the future?</h2>
+<p class="font-body-lg text-body-lg text-surface-variant max-w-xl mx-auto mb-10 relative z-10 opacity-90">
+                    Connect with our solution architects to discuss how we can transform your digital infrastructure.
+                </p>
+<div class="flex flex-col sm:flex-row gap-4 justify-center relative z-10">
+<button class="bg-electric-blue text-white px-10 py-5 rounded-xl font-headline-md text-body-md hover:shadow-lg hover:shadow-electric-blue/30 transition-all">
+                        Request a Consultation
+                    </button>
+<button class="bg-white/10 backdrop-blur-md text-white border border-white/20 px-10 py-5 rounded-xl font-headline-md text-body-md hover:bg-white/20 transition-all">
+                        Meet the Team
+                    </button>
+</div>
+</div>
+</section>
+</main>
+<!-- Footer -->
+<footer class="w-full bg-surface-container-lowest border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-16 grid grid-cols-2 md:grid-cols-4 gap-8">
+<div class="col-span-2 md:col-span-1">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary" style="cursor:pointer">InviteYou.ca</a>
+<p class="font-body-md text-body-md text-on-surface-variant mt-4 max-w-xs">Architecting custom business solutions with high-tech innovation and institutional reliability.</p>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Company</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="about.html">About</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="careers.html">Careers</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Contact</a></li>
+</ul>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Expertise</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="services.html">Services</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="solutions.html">Solutions</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="process.html">Process</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="portfolio.html">Portfolio</a></li>
+</ul>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Support</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="faq.html">FAQ</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Contact</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Get Started</a></li>
+</ul>
+</div>
+</div>
+<div class="border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-6 flex flex-col md:flex-row justify-between items-center gap-4">
+<p class="font-label-sm text-label-sm text-on-surface-variant">© 2024 InviteYou.ca Business Solutions. All rights reserved.</p>
+<div class="flex flex-wrap justify-center gap-6">
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Privacy Policy</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Terms of Service</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Cookie Policy</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Sitemap</a>
+</div>
+</div>
+</div>
+</footer>
+<script>
+        // Scroll Entrance Animation
+        const observerOptions = {
+            threshold: 0.1,
+            rootMargin: '0px 0px -50px 0px'
+        };
+
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('active');
+                }
+            });
+        }, observerOptions);
+
+        document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
+
+        // Interactive mouse movement effect on cards
+        document.querySelectorAll('.glass-card').forEach(card => {
+            card.addEventListener('mousemove', e => {
+                const rect = card.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                
+                card.style.setProperty('--mouse-x', `${x}px`);
+                card.style.setProperty('--mouse-y', `${y}px`);
+                
+                // Add a very subtle tilt
+                const centerX = rect.width / 2;
+                const centerY = rect.height / 2;
+                const rotateX = (y - centerY) / 20;
+                const rotateY = (centerX - x) / 20;
+                
+                card.style.transform = `perspective(1000px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) translateY(-4px)`;
+            });
+            
+            card.addEventListener('mouseleave', () => {
+                card.style.transform = 'perspective(1000px) rotateX(0) rotateY(0) translateY(0)';
+            });
+        });
+    </script>
+
+
+
+
+</body></html>

--- a/marketing/solutions.html
+++ b/marketing/solutions.html
@@ -1,0 +1,372 @@
+<!DOCTYPE html><html class="scroll-smooth" lang="en"><head>
+<meta charset="utf-8">
+<meta content="width=device-width, initial-scale=1.0" name="viewport">
+<title>Solutions | InviteYou.ca</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;600;700&amp;family=Inter:wght@400;500&amp;family=JetBrains+Mono:wght@500&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet">
+<script id="tailwind-config">
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            "colors": {
+                    "on-tertiary-fixed": "#410007",
+                    "outline-variant": "#c2c6d9",
+                    "tertiary-fixed": "#ffdad8",
+                    "on-secondary": "#ffffff",
+                    "inverse-surface": "#2d3135",
+                    "surface-tint": "#0053da",
+                    "error-container": "#ffdad6",
+                    "tertiary-fixed-dim": "#ffb3b1",
+                    "secondary-fixed-dim": "#44dfab",
+                    "on-surface": "#181c20",
+                    "tertiary": "#94393b",
+                    "on-secondary-fixed-variant": "#00513a",
+                    "surface-variant": "#e0e3e8",
+                    "inverse-on-surface": "#eef1f6",
+                    "on-secondary-fixed": "#002116",
+                    "on-secondary-container": "#007354",
+                    "on-primary": "#ffffff",
+                    "on-error-container": "#93000a",
+                    "ghost-white": "#F8F9FA",
+                    "secondary": "#006c4f",
+                    "on-error": "#ffffff",
+                    "soft-teal": "#20C997",
+                    "surface-subtle": "#FBF2F2",
+                    "on-primary-fixed-variant": "#003ea8",
+                    "background": "#f7f9ff",
+                    "outline": "#737687",
+                    "surface-container": "#ebeef3",
+                    "secondary-container": "#67fcc6",
+                    "surface-container-highest": "#e0e3e8",
+                    "surface-container-high": "#e5e8ee",
+                    "inverse-primary": "#b4c5ff",
+                    "on-tertiary-fixed-variant": "#7f292c",
+                    "on-primary-fixed": "#00174b",
+                    "primary-fixed": "#dbe1ff",
+                    "error": "#ba1a1a",
+                    "electric-blue": "#0062FF",
+                    "primary-fixed-dim": "#b4c5ff",
+                    "surface-bright": "#f7f9ff",
+                    "tertiary-container": "#b35052",
+                    "surface-container-lowest": "#ffffff",
+                    "surface-dim": "#d7dadf",
+                    "primary": "#004cca",
+                    "primary-container": "#0062ff",
+                    "secondary-fixed": "#67fcc6",
+                    "on-background": "#181c20",
+                    "surface": "#f7f9ff",
+                    "on-primary-container": "#f3f3ff",
+                    "on-tertiary-container": "#fff1ef",
+                    "surface-container-low": "#f1f4f9",
+                    "on-surface-variant": "#424656",
+                    "on-tertiary": "#ffffff"
+            },
+            "borderRadius": {
+                    "DEFAULT": "0.25rem",
+                    "lg": "0.5rem",
+                    "xl": "0.75rem",
+                    "full": "9999px"
+            },
+            "spacing": {
+                    "margin-mobile": "16px",
+                    "margin-desktop": "64px",
+                    "unit": "4px",
+                    "max-width": "1280px",
+                    "gutter": "24px"
+            },
+            "fontFamily": {
+                    "label-md": ["JetBrains Mono"],
+                    "headline-xl": ["Hanken Grotesk"],
+                    "headline-lg": ["Hanken Grotesk"],
+                    "body-md": ["Inter"],
+                    "headline-lg-mobile": ["Hanken Grotesk"],
+                    "label-sm": ["JetBrains Mono"],
+                    "headline-md": ["Hanken Grotesk"],
+                    "body-lg": ["Inter"]
+            },
+            "fontSize": {
+                    "label-md": ["14px", {"lineHeight": "20px", "letterSpacing": "0.05em", "fontWeight": "500"}],
+                    "headline-xl": ["64px", {"lineHeight": "72px", "letterSpacing": "-0.02em", "fontWeight": "700"}],
+                    "headline-lg": ["48px", {"lineHeight": "56px", "letterSpacing": "-0.01em", "fontWeight": "600"}],
+                    "body-md": ["16px", {"lineHeight": "24px", "fontWeight": "400"}],
+                    "headline-lg-mobile": ["32px", {"lineHeight": "40px", "fontWeight": "600"}],
+                    "label-sm": ["12px", {"lineHeight": "16px", "letterSpacing": "0.05em", "fontWeight": "500"}],
+                    "headline-md": ["32px", {"lineHeight": "40px", "fontWeight": "600"}],
+                    "body-lg": ["18px", {"lineHeight": "28px", "fontWeight": "400"}]
+            }
+          },
+        },
+      }
+    </script>
+<style>
+        .material-symbols-outlined {
+            font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+        }
+        .glass-card {
+            background: rgba(255, 255, 255, 0.7);
+            backdrop-filter: blur(12px);
+            border: 1px solid rgba(233, 236, 239, 1);
+        }
+        .transition-standard {
+            transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+        }
+        .hover-lift:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 40px 80px -20px rgba(0, 0, 0, 0.04);
+        }
+    </style>
+</head>
+<body class="bg-background text-on-surface font-body-md selection:bg-electric-blue/20">
+<!-- TopNavBar -->
+<header class="fixed top-0 left-0 w-full z-50 bg-surface/70 backdrop-blur-xl shadow-sm">
+<div class="flex justify-between items-center max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-4">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary tracking-tight" style="cursor:pointer">InviteYou.ca</a>
+<nav class="hidden md:flex items-center space-x-8">
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="services.html">Services</a>
+<a class="text-primary border-b-2 border-primary pb-1 font-semibold font-label-md text-label-md" href="solutions.html">Solutions</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="process.html">Process</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="portfolio.html">Portfolio</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="about.html">About</a>
+<a class="text-on-surface-variant hover:text-primary transition-colors duration-200 font-label-md text-label-md" href="contact.html">Contact</a>
+</nav>
+<a href="contact.html"><button class="bg-primary-container text-on-primary-container px-6 py-2.5 rounded-full font-label-md text-label-md hover:scale-105 hover:shadow-md transition-all duration-200 active:scale-95">Get Started</button></a>
+</div>
+</header>
+<main class="pt-20">
+<!-- Hero Section -->
+<section class="relative py-32 overflow-hidden">
+
+<div class="max-w-max-width mx-auto px-margin-desktop text-center">
+<div class="inline-block px-4 py-1.5 rounded-full bg-electric-blue/10 text-electric-blue font-label-md text-label-md uppercase mb-6 tracking-wider">
+                    Our Expertise
+                </div>
+<h1 class="font-headline-xl text-headline-xl md:text-headline-xl text-on-surface mb-8 tracking-tight max-w-4xl mx-auto">
+                    Tailored Solutions for Your <span class="text-electric-blue">Business</span>
+</h1>
+<p class="font-body-lg text-body-lg text-on-surface-variant max-w-2xl mx-auto mb-12">
+                    We engineer high-performance digital ecosystems that empower market leaders in Tech, Finance, and Retail to scale without friction.
+                </p>
+<div class="flex flex-wrap justify-center gap-4">
+<button class="bg-electric-blue text-white px-8 py-4 rounded-lg font-semibold hover-lift transition-standard shadow-lg shadow-electric-blue/20">
+                        Explore Solutions
+                    </button>
+<button class="border border-outline-variant text-on-surface px-8 py-4 rounded-lg font-semibold hover:bg-surface-container transition-standard">
+                        View Case Studies
+                    </button>
+</div>
+</div>
+</section>
+<!-- Industry Grid -->
+<section class="py-24 bg-surface-container-lowest">
+<div class="max-w-max-width mx-auto px-margin-desktop">
+<div class="grid grid-cols-1 md:grid-cols-3 gap-gutter">
+<!-- Tech Industry -->
+<div class="glass-card p-10 rounded-xl hover-lift transition-standard">
+<div class="w-14 h-14 bg-electric-blue/10 rounded-lg flex items-center justify-center text-electric-blue mb-8">
+<span class="material-symbols-outlined text-3xl" data-icon="rocket_launch">rocket_launch</span>
+</div>
+<h3 class="font-headline-md text-headline-md mb-4 text-on-surface">Tech &amp; SaaS</h3>
+<p class="text-on-surface-variant mb-8 font-body-md">Architecting high-availability cloud infrastructures and AI-driven platforms for rapid-growth software enterprises.</p>
+<ul class="space-y-4 mb-10">
+<li class="flex items-center gap-3 text-on-surface-variant">
+<span class="material-symbols-outlined text-soft-teal text-xl" data-icon="check_circle">check_circle</span>
+                                Microservices Architecture
+                            </li>
+<li class="flex items-center gap-3 text-on-surface-variant">
+<span class="material-symbols-outlined text-soft-teal text-xl" data-icon="check_circle">check_circle</span>
+                                DevOps Automation
+                            </li>
+</ul>
+<a class="text-electric-blue font-semibold flex items-center gap-2 group" href="#">
+                            Learn more <span class="material-symbols-outlined transition-transform group-hover:translate-x-1" data-icon="arrow_forward">arrow_forward</span>
+</a>
+</div>
+<!-- Finance Industry -->
+<div class="glass-card p-10 rounded-xl hover-lift transition-standard">
+<div class="w-14 h-14 bg-electric-blue/10 rounded-lg flex items-center justify-center text-electric-blue mb-8">
+<span class="material-symbols-outlined text-3xl" data-icon="account_balance">account_balance</span>
+</div>
+<h3 class="font-headline-md text-headline-md mb-4 text-on-surface">Finance &amp; Fintech</h3>
+<p class="text-on-surface-variant mb-8 font-body-md">Secure, compliant, and lightning-fast transactional systems designed for institutional-grade reliability.</p>
+<ul class="space-y-4 mb-10">
+<li class="flex items-center gap-3 text-on-surface-variant">
+<span class="material-symbols-outlined text-soft-teal text-xl" data-icon="check_circle">check_circle</span>
+                                Regulatory Tech (RegTech)
+                            </li>
+<li class="flex items-center gap-3 text-on-surface-variant">
+<span class="material-symbols-outlined text-soft-teal text-xl" data-icon="check_circle">check_circle</span>
+                                High-Frequency Data Pipelines
+                            </li>
+</ul>
+<a class="text-electric-blue font-semibold flex items-center gap-2 group" href="#">
+                            Learn more <span class="material-symbols-outlined transition-transform group-hover:translate-x-1" data-icon="arrow_forward">arrow_forward</span>
+</a>
+</div>
+<!-- Retail Industry -->
+<div class="glass-card p-10 rounded-xl hover-lift transition-standard">
+<div class="w-14 h-14 bg-electric-blue/10 rounded-lg flex items-center justify-center text-electric-blue mb-8">
+<span class="material-symbols-outlined text-3xl" data-icon="shopping_bag">shopping_bag</span>
+</div>
+<h3 class="font-headline-md text-headline-md mb-4 text-on-surface">Modern Retail</h3>
+<p class="text-on-surface-variant mb-8 font-body-md">Omnichannel commerce engines that bridge the gap between digital storefronts and physical experiences.</p>
+<ul class="space-y-4 mb-10">
+<li class="flex items-center gap-3 text-on-surface-variant">
+<span class="material-symbols-outlined text-soft-teal text-xl" data-icon="check_circle">check_circle</span>
+                                Headless Commerce Solutions
+                            </li>
+<li class="flex items-center gap-3 text-on-surface-variant">
+<span class="material-symbols-outlined text-soft-teal text-xl" data-icon="check_circle">check_circle</span>
+                                Predictive Inventory Systems
+                            </li>
+</ul>
+<a class="text-electric-blue font-semibold flex items-center gap-2 group" href="#">
+                            Learn more <span class="material-symbols-outlined transition-transform group-hover:translate-x-1" data-icon="arrow_forward">arrow_forward</span>
+</a>
+</div>
+</div>
+</div>
+</section>
+<!-- Why Choose Our Solutions -->
+<section class="py-32">
+<div class="max-w-max-width mx-auto px-margin-desktop">
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-20 items-center">
+<div>
+<div class="font-label-md text-label-md text-electric-blue uppercase mb-4">Core Values</div>
+<h2 class="font-headline-lg text-headline-lg mb-8 text-on-surface">Why Choose Our Solutions</h2>
+<div class="space-y-12">
+<div class="flex gap-6">
+<div class="shrink-0 w-12 h-12 bg-white shadow-sm border border-outline-variant flex items-center justify-center rounded-full text-electric-blue">
+<span class="material-symbols-outlined" data-icon="trending_up">trending_up</span>
+</div>
+<div>
+<h4 class="text-lg font-bold mb-2">Maximum ROI</h4>
+<p class="text-on-surface-variant">Our solutions are engineered for efficiency, reducing operational overhead and accelerating your time-to-market.</p>
+</div>
+</div>
+<div class="flex gap-6">
+<div class="shrink-0 w-12 h-12 bg-white shadow-sm border border-outline-variant flex items-center justify-center rounded-full text-electric-blue">
+<span class="material-symbols-outlined" data-icon="expand">expand</span>
+</div>
+<div>
+<h4 class="text-lg font-bold mb-2">Elastic Scalability</h4>
+<p class="text-on-surface-variant">Infrastructure that grows with you. We build systems that handle 10x traffic spikes without breaking a sweat.</p>
+</div>
+</div>
+<div class="flex gap-6">
+<div class="shrink-0 w-12 h-12 bg-white shadow-sm border border-outline-variant flex items-center justify-center rounded-full text-electric-blue">
+<span class="material-symbols-outlined" data-icon="shield">shield</span>
+</div>
+<div>
+<h4 class="text-lg font-bold mb-2">Ironclad Security</h4>
+<p class="text-on-surface-variant">Security isn't an afterthought; it's the foundation. We implement SOC2-level protocols from day one.</p>
+</div>
+</div>
+</div>
+</div>
+<div class="relative">
+<div class="aspect-square rounded-2xl overflow-hidden shadow-2xl relative z-10">
+<img class="w-full h-full object-cover" data-alt="A futuristic professional office environment with minimalist furniture and high-tech glass walls. The lighting is bright and luminous, reflecting a clean light-mode aesthetic with subtle electric blue glowing accents. A diverse team of professionals is visible in the background, engaged in collaborative work in a calm, focused atmosphere." src="https://lh3.googleusercontent.com/aida-public/AB6AXuAkjjzrUrKOvvSRQ1A_wKht_t1MluEtdwk07-jhOUbQrANJs5ekPY7VcRw7IS_ImgTJWYQlrJwDUwFcxT6onXBjBfU5t9t4VKPoXa5JBzrHzWNu11pmz6qC0EK0FkkhSIZPsB_RgGIGvwyd-yAsTTkxoEMXb3S1S9xYKo9mKMdWenL3DAi-2NQZYhquLyBzVeoZtK6PqL6cEQuSUy49Kc8dvjKr9TwM6_1wZJ9mgHuhjm4jrLagcK-wpSvKBb8S031bR7ZtrNKis6c">
+</div>
+<div class="absolute -bottom-10 -right-10 w-64 h-64 bg-electric-blue/5 rounded-full blur-3xl -z-0"></div>
+<div class="absolute -top-10 -left-10 w-64 h-64 bg-soft-teal/5 rounded-full blur-3xl -z-0"></div>
+</div>
+</div>
+</div>
+</section>
+<!-- CTA Section -->
+<section class="py-24">
+<div class="max-w-max-width mx-auto px-margin-desktop">
+<div class="bg-primary-container text-on-primary-container rounded-3xl p-16 text-center relative overflow-hidden">
+<div class="absolute inset-0 opacity-10 pointer-events-none">
+
+</div>
+<div class="relative z-10">
+<h2 class="font-headline-lg text-headline-lg mb-6">Ready to Transform Your Business?</h2>
+<p class="font-body-lg text-body-lg mb-10 max-w-2xl mx-auto opacity-90">
+                            Get in touch with our solution architects to build a custom digital strategy that drives real results.
+                        </p>
+<button class="bg-white text-primary px-10 py-4 rounded-lg font-bold text-lg hover-lift transition-standard shadow-xl">
+                            Get a Custom Quote
+                        </button>
+</div>
+</div>
+</div>
+</section>
+</main>
+<!-- Footer -->
+<footer class="w-full bg-surface-container-lowest border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-16 grid grid-cols-2 md:grid-cols-4 gap-8">
+<div class="col-span-2 md:col-span-1">
+<a href="index.html" class="font-headline-md text-headline-md font-bold text-primary" style="cursor:pointer">InviteYou.ca</a>
+<p class="font-body-md text-body-md text-on-surface-variant mt-4 max-w-xs">Architecting custom business solutions with high-tech innovation and institutional reliability.</p>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Company</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="about.html">About</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="careers.html">Careers</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Contact</a></li>
+</ul>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Expertise</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="services.html">Services</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="solutions.html">Solutions</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="process.html">Process</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="portfolio.html">Portfolio</a></li>
+</ul>
+</div>
+<div>
+<h4 class="font-label-md text-label-md uppercase tracking-widest text-on-surface mb-4">Support</h4>
+<ul class="space-y-3">
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="faq.html">FAQ</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Contact</a></li>
+<li><a class="text-on-surface-variant hover:text-primary transition-all text-body-md font-body-md" href="contact.html">Get Started</a></li>
+</ul>
+</div>
+</div>
+<div class="border-t border-surface-variant">
+<div class="max-w-max-width mx-auto px-margin-mobile md:px-margin-desktop py-6 flex flex-col md:flex-row justify-between items-center gap-4">
+<p class="font-label-sm text-label-sm text-on-surface-variant">© 2024 InviteYou.ca Business Solutions. All rights reserved.</p>
+<div class="flex flex-wrap justify-center gap-6">
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Privacy Policy</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Terms of Service</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Cookie Policy</a>
+<a class="text-on-surface-variant hover:text-primary transition-all text-sm font-body-md" href="#">Sitemap</a>
+</div>
+</div>
+</div>
+</footer>
+<script>
+        // Micro-interaction for cards
+        document.querySelectorAll('.glass-card').forEach(card => {
+            card.addEventListener('mousemove', (e) => {
+                const rect = card.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                card.style.setProperty('--mouse-x', `${x}px`);
+                card.style.setProperty('--mouse-y', `${y}px`);
+            });
+        });
+
+        // Simple scroll reveal
+        const reveal = () => {
+            const reveals = document.querySelectorAll('.glass-card, .relative');
+            reveals.forEach(element => {
+                const windowHeight = window.innerHeight;
+                const elementTop = element.getBoundingClientRect().top;
+                const elementVisible = 150;
+                if (elementTop < windowHeight - elementVisible) {
+                    element.style.opacity = '1';
+                    element.style.transform = 'translateY(0)';
+                }
+            });
+        };
+        
+        window.addEventListener('scroll', reveal);
+    </script>
+</body></html>


### PR DESCRIPTION
## Summary
Adds the new **static marketing site** (9 pages) under `marketing/` plus a **separate deploy workflow**. Once live, `inviteyou.ca` + `www` serve this static site; **`we.inviteyou.ca`** (the React invitation app) and **`api.inviteyou.ca`** (backend) are **untouched**.

## What is included
- `marketing/` — 9 cross-linked static pages (HTML + Tailwind), plus the `build_site.py` / `connect_nav.py` generators.
- `.github/workflows/marketing.yml` — deploys `marketing/` over SSH (`easingthemes/ssh-deploy`) to `MARKETING_TARGET_PATH` (`/var/www/inviteyou-web`) on push to `main` under `marketing/**` or manual dispatch. Reuses existing `SERVER_SSH_KEY` / `SSH_HOST` / `SSH_USER` secrets.
- `marketing/DEPLOY.md` + `marketing/nginx-inviteyou-marketing.conf` — one-time server/Nginx setup, TLS, verification, and rollback.

## Before go-live (needs SSH to the droplet)
1. Create web root `/var/www/inviteyou-web` (matches `MARKETING_TARGET_PATH`, already set as a repo secret).
2. Add the Nginx block from `marketing/nginx-inviteyou-marketing.conf` for apex + www; leave `we.`/`api.` blocks unchanged.
3. Ensure TLS cert covers `inviteyou.ca` + `www`; `nginx -t && systemctl reload nginx`.

## Verify after deploy
- `inviteyou.ca` / `www` -> new marketing site (links + `services.html#...` anchors work).
- `we.inviteyou.ca` -> still "You have been invited!" (unchanged).
- `api.inviteyou.ca` -> unchanged.

## Rollback
Disable the new Nginx block (remove the symlink) or restore apex/www to the previous proxy block, then reload nginx. No DNS changes involved.
